### PR TITLE
feat(desktop): add Electron desktop wrapper (T19)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ Thumbs.db
 .claude/
 .codex-pr29-fix/
 .codex-t02-worktree/
+
+# Electron desktop
+desktop/node_modules/
+desktop/out/
+desktop/dist/

--- a/README.md
+++ b/README.md
@@ -114,3 +114,61 @@ This project now contains two Django apps:
 
 - `accounts`
 - `chat`
+
+## Desktop Client (Electron)
+
+iChat Pro includes a lightweight Electron wrapper for Phase 1 desktop delivery.
+The desktop app loads the local Django web client and can either start Django
+for you or connect to an already running backend.
+
+### Prerequisites
+
+- Node.js 18+ and npm
+- Python virtual environment with the Django dependencies installed
+
+### Quick Start
+
+```powershell
+cd desktop
+npm install
+npm start
+```
+
+By default, Electron starts Django with:
+
+```text
+python manage.py runserver 127.0.0.1:8000
+```
+
+The launcher prefers the project virtual environment when present:
+
+- Windows: `.venv\Scripts\python.exe`
+- macOS/Linux: `.venv/bin/python`
+
+### Development Mode
+
+```powershell
+cd desktop
+npm run dev
+```
+
+This opens Chromium DevTools next to the app window.
+
+### Use an Existing Django Server
+
+If Django is already running, skip Electron's backend launcher:
+
+```powershell
+$env:ICHAT_SKIP_DJANGO = "1"
+cd desktop
+npm start
+```
+
+### Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `ICHAT_HOST` | `127.0.0.1` | Django host loaded by Electron |
+| `ICHAT_PORT` | `8000` | Django port loaded by Electron |
+| `ICHAT_PYTHON` | auto-detect | Python executable used to start Django |
+| `ICHAT_SKIP_DJANGO` | unset | Set to `1` to connect to an already running backend |

--- a/desktop/.npmrc
+++ b/desktop/.npmrc
@@ -1,0 +1,1 @@
+electron_mirror=https://npmmirror.com/mirrors/electron/

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,0 +1,213 @@
+const { app, BrowserWindow, dialog, shell } = require('electron');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const DJANGO_HOST = process.env.ICHAT_HOST || '127.0.0.1';
+const DJANGO_PORT = process.env.ICHAT_PORT || '8000';
+const DJANGO_ORIGIN = `http://${DJANGO_HOST}:${DJANGO_PORT}`;
+const DJANGO_READY_URL = `${DJANGO_ORIGIN}/login/`;
+const DJANGO_APP_URL = DJANGO_ORIGIN;
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const IS_DEV = process.argv.includes('--dev');
+
+let djangoProcess = null;
+let mainWindow = null;
+
+function localPythonCandidates() {
+  const candidates = [];
+  if (process.env.ICHAT_PYTHON) {
+    candidates.push(process.env.ICHAT_PYTHON);
+  }
+  if (process.platform === 'win32') {
+    candidates.push(path.join(PROJECT_ROOT, '.venv', 'Scripts', 'python.exe'));
+    candidates.push('python');
+  } else {
+    candidates.push(path.join(PROJECT_ROOT, '.venv', 'bin', 'python'));
+    candidates.push('python3');
+    candidates.push('python');
+  }
+  return candidates;
+}
+
+function resolvePythonExecutable() {
+  for (const candidate of localPythonCandidates()) {
+    if (path.isAbsolute(candidate) && fs.existsSync(candidate)) {
+      return candidate;
+    }
+    if (!path.isAbsolute(candidate)) {
+      return candidate;
+    }
+  }
+  return 'python';
+}
+
+function startDjangoServer() {
+  const pythonExecutable = resolvePythonExecutable();
+  djangoProcess = spawn(
+    pythonExecutable,
+    ['manage.py', 'runserver', `${DJANGO_HOST}:${DJANGO_PORT}`],
+    {
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        PYTHONUNBUFFERED: '1',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    },
+  );
+
+  djangoProcess.stdout.on('data', (data) => {
+    console.log(`[Django] ${data.toString().trim()}`);
+  });
+  djangoProcess.stderr.on('data', (data) => {
+    console.error(`[Django] ${data.toString().trim()}`);
+  });
+  djangoProcess.on('error', (error) => {
+    console.error(`[Django] Failed to start: ${error.message}`);
+  });
+  djangoProcess.on('exit', (code) => {
+    console.log(`[Django] Server exited with code ${code}`);
+    djangoProcess = null;
+  });
+}
+
+function stopDjangoServer() {
+  if (!djangoProcess) return;
+  const processToStop = djangoProcess;
+  djangoProcess = null;
+  if (process.platform === 'win32') {
+    spawn('taskkill', ['/pid', String(processToStop.pid), '/f', '/t'], {
+      windowsHide: true,
+      stdio: 'ignore',
+    });
+  } else {
+    processToStop.kill('SIGTERM');
+  }
+}
+
+function waitForDjangoReady(url, attempts = 40, delayMs = 500) {
+  return new Promise((resolve, reject) => {
+    let remaining = attempts;
+    const tryRequest = () => {
+      const request = http.get(url, (response) => {
+        response.resume();
+        if (response.statusCode >= 200 && response.statusCode < 500) {
+          resolve();
+          return;
+        }
+        retry();
+      });
+      request.on('error', retry);
+      request.setTimeout(2000, () => {
+        request.destroy();
+        retry();
+      });
+    };
+
+    const retry = () => {
+      remaining -= 1;
+      if (remaining <= 0) {
+        reject(new Error(`Django did not become ready at ${url}`));
+        return;
+      }
+      setTimeout(tryRequest, delayMs);
+    };
+
+    tryRequest();
+  });
+}
+
+function isAllowedExternalUrl(rawUrl) {
+  try {
+    const parsed = new URL(rawUrl);
+    return ['https:', 'http:', 'mailto:'].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+function isDjangoOrigin(rawUrl) {
+  try {
+    return new URL(rawUrl).origin === DJANGO_ORIGIN;
+  } catch {
+    return false;
+  }
+}
+
+function createWindow() {
+  mainWindow = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    minWidth: 900,
+    minHeight: 600,
+    title: 'iChat Pro',
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      preload: path.join(__dirname, 'preload.js'),
+    },
+  });
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (isAllowedExternalUrl(url)) {
+      shell.openExternal(url);
+    }
+    return { action: 'deny' };
+  });
+
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (!isDjangoOrigin(url)) {
+      event.preventDefault();
+      if (isAllowedExternalUrl(url)) {
+        shell.openExternal(url);
+      }
+    }
+  });
+
+  mainWindow.loadURL(DJANGO_APP_URL);
+
+  if (IS_DEV) {
+    mainWindow.webContents.openDevTools();
+  }
+
+  mainWindow.on('closed', () => {
+    mainWindow = null;
+  });
+}
+
+app.whenReady().then(async () => {
+  if (process.env.ICHAT_SKIP_DJANGO !== '1') {
+    startDjangoServer();
+  }
+
+  try {
+    await waitForDjangoReady(DJANGO_READY_URL);
+  } catch (error) {
+    dialog.showErrorBox(
+      'iChat Pro backend unavailable',
+      `${error.message}\n\nStart Django manually or set ICHAT_HOST / ICHAT_PORT.`,
+    );
+    app.quit();
+    return;
+  }
+
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('before-quit', stopDjangoServer);
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ichat-pro-desktop",
+  "version": "1.0.0",
+  "description": "iChat Pro desktop client",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron .",
+    "dev": "electron . --dev"
+  },
+  "author": "iChat Pro Team",
+  "license": "MIT",
+  "devDependencies": {
+    "electron": "^39.0.0"
+  }
+}

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -1,0 +1,6 @@
+const { contextBridge } = require('electron');
+
+contextBridge.exposeInMainWorld('iChatDesktop', {
+  isElectron: true,
+  platform: process.platform,
+});


### PR DESCRIPTION
## Summary

Clean replacement for the closed T19 Electron PR (#44). This PR adds only the desktop wrapper and related documentation, without carrying the stale T16 chat UI changes from the old branch.

## Changes

- Add `desktop/main.js` Electron main process wrapper
- Add minimal `desktop/preload.js` bridge with context isolation
- Add `desktop/package.json` and local Electron mirror config
- Update `.gitignore` for Electron build artifacts
- Document desktop startup and environment variables in README

## Safety / robustness

- Keeps `nodeIntegration: false` and `contextIsolation: true`
- Enables Electron renderer sandbox
- Prefers project `.venv` Python before falling back to `python`
- Waits for Django readiness via HTTP polling instead of a fixed sleep
- Restricts external link opening to `http:`, `https:`, and `mailto:`
- Prevents in-window navigation away from the configured Django origin

## Verification

- `node --check desktop/main.js`
- `node --check desktop/preload.js`
- `python manage.py check`
- `git diff --check`

Note: local `npm` is broken on this machine (`npm-cli.js` missing under AppData), so package installation could not be executed here.

Closes #20