### PR TITLE
T26: Support contact search by username, nickname, and user ID

### DIFF
--- a/accounts/tests.py
+++ b/accounts/tests.py
@@ -694,6 +694,64 @@ class ContactViewTests(TestCase):
             ).exists(),
         )
 
+    # ── T26: multi-field search ────────────────────────────────────
+
+    def test_search_by_nickname(self):
+        # Profile already auto-created by post_save signal — update it
+        UserProfile.objects.filter(user=self.bob).update(nickname='Bobby')
+        response = self.client.get(
+            reverse('search_users'), {'q': 'Bobby'},
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data['results']), 1)
+        self.assertEqual(data['results'][0]['username'], 'bob')
+
+    def test_search_by_partial_nickname(self):
+        UserProfile.objects.filter(user=self.charlie).update(nickname='Charles')
+        response = self.client.get(
+            reverse('search_users'), {'q': 'char'},
+        )
+        data = response.json()
+        self.assertTrue(any(r['username'] == 'charlie' for r in data['results']))
+
+    def test_search_by_user_id(self):
+        response = self.client.get(
+            reverse('search_users'), {'q': str(self.bob.id)},
+        )
+        data = response.json()
+        self.assertEqual(len(data['results']), 1)
+        self.assertEqual(data['results'][0]['username'], 'bob')
+
+    def test_search_result_includes_nickname(self):
+        UserProfile.objects.filter(user=self.bob).update(nickname='Bobster')
+        response = self.client.get(
+            reverse('search_users'), {'q': 'bob'},
+        )
+        data = response.json()
+        result = data['results'][0]
+        self.assertIn('nickname', result)
+        self.assertEqual(result['nickname'], 'Bobster')
+
+    def test_send_request_by_user_id(self):
+        response = self.client.post(
+            reverse('friend_request_send'),
+            {'user_id': str(self.charlie.id)},
+        )
+        self.assertRedirects(response, self.CONTACTS_URL)
+        self.assertTrue(
+            FriendRequest.objects.filter(
+                sender=self.alice, receiver=self.charlie, status='pending',
+            ).exists(),
+        )
+
+    def test_search_by_username_still_works(self):
+        response = self.client.get(
+            reverse('search_users'), {'q': 'char'},
+        )
+        data = response.json()
+        self.assertTrue(any(r['username'] == 'charlie' for r in data['results']))
+
 
 # ─── Profile ──────────────────────────────────────────────────────────
 

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -192,19 +192,39 @@ def contact_list_view(request):
 
 @login_required(login_url='login')
 def search_users(request):
-    """Search for users (JSON endpoint for the contact modal)."""
+    """Search for users by username, nickname, or user ID (JSON endpoint)."""
     query = request.GET.get('q', '').strip()
     results = []
 
     if query:
-        users = User.objects.filter(
-            username__icontains=query,
-        ).exclude(
-            id=request.user.id,
+        current_user = request.user
+
+        # Match by exact user ID
+        id_matches = User.objects.none()
+        if query.isdigit():
+            id_matches = User.objects.filter(id=int(query))
+
+        # Match by username or nickname
+        name_matches = User.objects.filter(
+            models.Q(username__icontains=query)
+            | models.Q(profile__nickname__icontains=query),
+        )
+
+        # Combine, exclude self, deduplicate, limit
+        users = (
+            (id_matches | name_matches)
+            .exclude(id=current_user.id)
+            .distinct()
+            .select_related('profile')
         )[:20]
 
-        current_user = request.user
         for user in users:
+            # Resolve nickname (UserProfile may not exist yet)
+            try:
+                nickname = user.profile.nickname or ''
+            except UserProfile.DoesNotExist:
+                nickname = ''
+
             is_contact = Contact.objects.filter(
                 (models.Q(user=current_user) & models.Q(contact=user))
                 | (models.Q(user=user) & models.Q(contact=current_user)),
@@ -225,6 +245,7 @@ def search_users(request):
             results.append({
                 'id': user.id,
                 'username': user.username,
+                'nickname': nickname,
                 'is_contact': is_contact,
                 'has_pending_out': has_pending_out,
                 'has_pending_in': has_pending_in,
@@ -236,14 +257,18 @@ def search_users(request):
 @login_required(login_url='login')
 @require_http_methods(['POST'])
 def friend_request_send(request):
-    """Send a friend request to another user."""
+    """Send a friend request to another user (by username or user ID)."""
     username = request.POST.get('username', '').strip()
+    user_id = request.POST.get('user_id', '').strip()
 
-    if not username:
-        messages.error(request, 'Please provide a username.')
+    if not username and not user_id:
+        messages.error(request, 'Please provide a username or user ID.')
         return redirect('contacts')
 
-    receiver = get_object_or_404(User, username=username)
+    if user_id and user_id.isdigit():
+        receiver = get_object_or_404(User, id=int(user_id))
+    else:
+        receiver = get_object_or_404(User, username=username)
 
     if receiver == request.user:
         messages.error(request, 'You cannot add yourself as a contact.')

--- a/templates/pages/contacts.html
+++ b/templates/pages/contacts.html
@@ -41,7 +41,7 @@
               type="text"
               id="contact-search-input"
               name="username"
-              placeholder="Search users by username..."
+              placeholder="Search by username, nickname, or user ID..."
               class="w-full px-4 py-2.5 rounded-custom-md border border-borderColor bg-bgSearch text-textMain placeholder-textSecondary/60 text-sm focus:outline-none focus:ring-2 focus:ring-brand-light dark:focus:ring-brand-dark transition-all"
               required
               oninput="liveSearchContacts(this.value)"
@@ -202,6 +202,8 @@
       } else if (r.has_pending_in) {
         badge = '<span class="text-[10px] px-2 py-0.5 rounded-full bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400 font-medium">Wants to add you</span>';
       }
+      const displayName = r.nickname ? `${r.nickname} (@${r.username})` : r.username;
+      const subInfo = r.nickname ? `<span class="text-[10px] text-textSecondary">ID: ${r.id}</span>` : `<span class="text-[10px] text-textSecondary">ID: ${r.id}</span>`;
       return `
         <div class="flex items-center justify-between px-4 py-3 hover:bg-bgSearch transition-colors cursor-pointer"
           onclick="document.getElementById('contact-search-input').value='${r.username}'; dropdown.classList.add('hidden');">
@@ -209,7 +211,10 @@
             <div class="w-8 h-8 rounded-full bg-brand-light dark:bg-brand-dark text-white flex items-center justify-center font-bold text-xs">
               ${r.username.charAt(0).toUpperCase()}
             </div>
-            <span class="text-sm font-medium text-textMain">${r.username}</span>
+            <div class="flex flex-col">
+              <span class="text-sm font-medium text-textMain">${displayName}</span>
+              ${subInfo}
+            </div>
             ${badge}
           </div>
         </div>


### PR DESCRIPTION
- Extend search_users view to search by username, nickname (via UserProfile), and exact user ID
- Include nickname in search JSON results
- Update friend_request_send to accept user_id as alternative to username
- Update contacts template with improved search placeholder and result display
- Add 6 new tests (90 total)

## Summary
- 

## Related Issue
Closes #36

## Checklist
- [ ] I created this PR from a feature branch, not from `main`.
- [ ] I linked the related Issue.
- [ ] I ran the relevant local checks.
- [ ] I updated docs or screenshots when needed.
