### PR TITLE
[codex] Add P2 T09-T10 & T12-T14 & T16 frontend interaction flows

### DIFF
--- a/chat/views.py
+++ b/chat/views.py
@@ -562,6 +562,7 @@ def forward_message_view(request, conversation_id):
                     algorithm=r.get('algorithm', 'AES-256-GCM'),
                     sender_key_version=r.get('sender_key_version'),
                     receiver_key_version=r.get('receiver_key_version'),
+                    membership_version=data.get('membership_version'),
                 )
                 for r in recipients
             ]

--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -145,6 +145,57 @@ body.sidebar-resizing .sidebar-resize-handle::after {
   box-shadow: 0 4px 12px rgba(0,0,0,0.1);
 }
 
+.security-status-chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
+  max-width: 100%;
+  padding: 3px 9px;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: normal;
+  text-align: center;
+}
+
+.security-status-loading {
+  background: var(--color-search-bg);
+  color: var(--color-text-secondary);
+}
+
+.security-status-verified {
+  border-color: rgba(16, 185, 129, 0.3);
+  background: rgba(16, 185, 129, 0.1);
+  color: #059669;
+}
+
+.security-status-unverified {
+  border-color: rgba(245, 158, 11, 0.35);
+  background: rgba(245, 158, 11, 0.12);
+  color: #b45309;
+}
+
+.security-status-danger,
+.security-status-missing {
+  border-color: rgba(239, 68, 68, 0.32);
+  background: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+}
+
+.security-trust-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid rgba(127, 127, 127, 0.16);
+  border-radius: var(--radius-md);
+  background: var(--color-search-bg);
+}
+
 [data-theme="dark"] .chat-empty-badge {
   background-color: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.05);
@@ -1964,4 +2015,441 @@ input:checked + .slider:before {
 
 [data-theme="dark"] .chat-item-btn.active .unread-badge {
   color: #6d5dfc !important;
+}
+
+/* ==========================================================================
+   P2 T09: Contacts FAB (Floating Action Button)
+   ========================================================================== */
+
+#contacts-fab-btn.expanded {
+  transform: rotate(45deg) !important;
+}
+
+.fab-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  width: 100%;
+  padding: 0.625rem 1rem;
+  font-size: 0.8125rem;
+  color: var(--color-text-main);
+  transition: background-color 0.12s;
+  text-align: left;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.fab-menu-item:hover:not(.cursor-not-allowed) {
+  background-color: var(--color-search-bg);
+}
+
+/* ==========================================================================
+   P2 T10: Search Sidebar
+   ========================================================================== */
+
+/* Search type tabs */
+.search-type-tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.search-type-tab {
+  padding: 0.375rem 0.875rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border-radius: 999px;
+  color: var(--color-text-secondary);
+  transition: all 0.15s;
+  white-space: nowrap;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.search-type-tab.active {
+  background-color: var(--color-primary);
+  color: white;
+}
+
+.search-type-tab:not(.active):hover {
+  background-color: var(--color-search-bg);
+  color: var(--color-text-main);
+}
+
+/* Search result items */
+.search-result-group-label {
+  padding: 0.5rem 1rem;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.025em;
+  color: var(--color-text-secondary);
+  background: var(--color-sidebar-bg);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.search-result-item {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.625rem 1rem;
+  cursor: pointer;
+  transition: background-color 0.12s;
+  width: 100%;
+  border: none;
+  background: none;
+  text-align: left;
+}
+
+.search-result-item:hover {
+  background-color: var(--color-search-bg);
+}
+
+/* ==========================================================================
+   Context Menu (right-click / long-press)
+   ========================================================================== */
+
+.context-menu-backdrop {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 249;
+  /* Transparent layer that captures outside clicks */
+}
+
+.context-menu {
+  position: fixed;
+  z-index: 250;
+  min-width: 200px;
+  max-width: 280px;
+  padding: 6px;
+  background: var(--color-sidebar-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg, 16px);
+  box-shadow: 0 10px 38px -10px rgba(0, 0, 0, 0.18),
+              0 4px 16px -6px rgba(0, 0, 0, 0.12);
+  backdrop-filter: blur(20px) saturate(190%);
+  -webkit-backdrop-filter: blur(20px) saturate(190%);
+  opacity: 0;
+  transform: scale(0.92);
+  transform-origin: top left;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+  pointer-events: none;
+  user-select: none;
+}
+
+.context-menu-visible {
+  opacity: 1;
+  transform: scale(1);
+  pointer-events: auto;
+}
+
+.context-menu-item {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0 10px;
+  height: 38px;
+  border: none;
+  background: transparent;
+  color: var(--color-text-main);
+  font-size: 0.8125rem;
+  font-weight: 500;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background-color 0.1s;
+  text-align: left;
+  font-family: inherit;
+  gap: 10px;
+}
+
+.context-menu-item:hover,
+.context-menu-item.focused {
+  background-color: var(--color-search-bg);
+}
+
+.context-menu-item.danger {
+  color: #ef4444;
+}
+
+.context-menu-item.danger:hover,
+.context-menu-item.danger.focused {
+  background-color: rgba(239, 68, 68, 0.1);
+}
+
+.context-menu-item-icon {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.context-menu-item-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.context-menu-divider {
+  height: 1px;
+  background: var(--color-border);
+  opacity: 0.5;
+  margin: 4px 6px;
+}
+
+/* Dark theme adjustments */
+[data-theme="dark"] .context-menu {
+  box-shadow: 0 10px 38px -10px rgba(0, 0, 0, 0.48),
+              0 4px 16px -6px rgba(0, 0, 0, 0.32);
+}
+
+[data-theme="dark"] .context-menu-item.danger {
+  color: #f87171;
+}
+
+/* ==========================================================================
+   Reply Quote Banner
+   ========================================================================== */
+
+.reply-quote-banner {
+  display: flex;
+  align-items: center;
+  max-width: 820px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 6px 12px;
+  background: var(--color-sidebar-bg);
+  border-left: 3px solid var(--color-primary);
+  border-radius: 10px 10px 0 0;
+  gap: 10px;
+  font-size: 0.8125rem;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.reply-quote-banner:hover {
+  background: var(--color-search-bg);
+}
+
+.reply-quote-preview {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-secondary);
+}
+
+.reply-quote-sender {
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.reply-quote-close {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  color: var(--color-text-secondary);
+  border-radius: 50%;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+}
+
+.reply-quote-close:hover {
+  background: var(--color-bg);
+  color: var(--color-text-main);
+}
+
+/* ==========================================================================
+   Typing Indicator
+   ========================================================================== */
+
+.typing-indicator-dots {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  vertical-align: middle;
+}
+
+.typing-dot {
+  width: 5px;
+  height: 5px;
+  background: var(--color-primary);
+  border-radius: 50%;
+  animation: typingBounce 1.3s ease-in-out infinite;
+}
+
+.typing-dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.typing-dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes typingBounce {
+  0%, 60%, 100% {
+    transform: translateY(0);
+    opacity: 0.4;
+  }
+  30% {
+    transform: translateY(-4px);
+    opacity: 1;
+  }
+}
+
+/* ==========================================================================
+   WebSocket Connection Status Badge
+   ========================================================================== */
+
+.connection-badge {
+  position: fixed;
+  top: 68px;
+  right: 12px;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 9999px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-4px);
+  transition: opacity 0.3s, transform 0.3s;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+}
+
+.connection-badge.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.connection-badge.connected {
+  background: rgba(34, 197, 94, 0.15);
+  color: #16a34a;
+  border: 1px solid rgba(34, 197, 94, 0.25);
+}
+
+.connection-badge.reconnecting {
+  background: rgba(234, 179, 8, 0.15);
+  color: #ca8a04;
+  border: 1px solid rgba(234, 179, 8, 0.25);
+}
+
+.connection-badge.disconnected {
+  background: rgba(239, 68, 68, 0.15);
+  color: #dc2626;
+  border: 1px solid rgba(239, 68, 68, 0.25);
+}
+
+/* ==========================================================================
+   Enhanced Message Status Icons
+   ========================================================================== */
+
+.msg-status-icon {
+  flex-shrink: 0;
+}
+
+.msg-status-sending {
+  opacity: 0.5;
+}
+
+.msg-status-failed {
+  color: #ef4444 !important;
+}
+
+.msg-status-read {
+  color: var(--color-primary);
+}
+
+/* ==========================================================================
+   Conversation Item Status Icons (sidebar)
+   ========================================================================== */
+
+.conv-status-icons {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  margin-left: 4px;
+  flex-shrink: 0;
+}
+
+.conv-icon-pin {
+  color: var(--color-primary);
+  width: 12px;
+  height: 12px;
+}
+
+.conv-icon-muted {
+  color: var(--color-text-secondary);
+  opacity: 0.6;
+  width: 12px;
+  height: 12px;
+}
+
+/* ==========================================================================
+   System Notice / Recall styling
+   ========================================================================== */
+
+.system-notice-recalled {
+  font-style: italic;
+  opacity: 0.65;
+}
+
+.search-result-item .result-avatar {
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.875rem;
+  color: white;
+  flex-shrink: 0;
+}
+
+.search-result-item .result-info {
+  min-width: 0;
+  flex: 1;
+}
+
+.search-result-item .result-name {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--color-text-main);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.search-result-item .result-subtitle {
+  font-size: 0.6875rem;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Placeholder tab empty state */
+.search-placeholder-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 3rem 1rem;
+  color: var(--color-text-secondary);
 }

--- a/static/js/chat-conversation-actions.js
+++ b/static/js/chat-conversation-actions.js
@@ -1,0 +1,403 @@
+/**
+ * iChat Pro — Conversation Actions (T12)
+ *
+ * Provides context-menu handlers for sidebar conversation items:
+ * pin / unpin, mute / unmute, archive / unarchive, clear history,
+ * delete (hide), mark read / unread.
+ *
+ * Depends on: window.ContextMenu, global conversations[], conversationsById{},
+ *              fetchConversations(), renderChatList(), selectChat(), showToast(),
+ *              currentLanguage, getCookie()
+ */
+
+(function () {
+  'use strict';
+
+  // --- Helpers ---
+
+  function getCookie(name) {
+    var value = '; ' + document.cookie;
+    var parts = value.split('; ' + name + '=');
+    if (parts.length === 2) return parts.pop().split(';').shift();
+    return null;
+  }
+
+  function t(key, fallback) {
+    if (typeof window.translations !== 'undefined' &&
+        window.translations[currentLanguage] &&
+        window.translations[currentLanguage][key]) {
+      return window.translations[currentLanguage][key];
+    }
+    return fallback || key;
+  }
+
+  function csrfHeaders() {
+    var headers = {
+      'Content-Type': 'application/json',
+    };
+    var token = getCookie('csrftoken');
+    if (token) {
+      headers['X-CSRFToken'] = token;
+    }
+    return headers;
+  }
+
+  // --- API calls ---
+
+  async function apiPost(url, body) {
+    var resp = await fetch(url, {
+      method: 'POST',
+      headers: csrfHeaders(),
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!resp.ok) {
+      var errText = '';
+      try { errText = await resp.text(); } catch (_) {}
+      throw new Error('API error ' + resp.status + ': ' + errText);
+    }
+    return resp.json().catch(function () { return null; });
+  }
+
+  async function apiDelete(url) {
+    var resp = await fetch(url, {
+      method: 'DELETE',
+      headers: csrfHeaders(),
+    });
+    if (!resp.ok) {
+      var errText = '';
+      try { errText = await resp.text(); } catch (_) {}
+      throw new Error('API error ' + resp.status + ': ' + errText);
+    }
+    return resp.json().catch(function () { return null; });
+  }
+
+  // --- Actions ---
+
+  function pinConversation(conv) {
+    var isPinned = conv.is_pinned;
+    var url = '/api/conversations/' + conv.id + '/pin/';
+    var promise = isPinned ? apiDelete(url) : apiPost(url);
+    promise
+      .then(function () {
+        window.showToast(isPinned ? t('convUnpinned', 'Unpinned') : t('convPinned', 'Pinned'));
+        if (typeof window.fetchConversations === 'function') {
+          window.fetchConversations();
+        }
+      })
+      .catch(function () {
+        window.showToast(t('convActionFailed', 'Action failed'));
+      });
+  }
+
+  function muteConversation(conv, durationMinutes) {
+    var url = '/api/conversations/' + conv.id + '/mute/';
+    apiPost(url, { duration_minutes: durationMinutes })
+      .then(function () {
+        conv.muted_until = new Date(Date.now() + durationMinutes * 60000).toISOString();
+        window.showToast(t('convMuted', 'Muted'));
+        if (typeof window.renderChatList === 'function') {
+          window.renderChatList();
+        }
+      })
+      .catch(function () {
+        window.showToast(t('convActionFailed', 'Action failed'));
+      });
+  }
+
+  function unmuteConversation(conv) {
+    var url = '/api/conversations/' + conv.id + '/mute/';
+    apiDelete(url)
+      .then(function () {
+        conv.muted_until = null;
+        window.showToast(t('convUnmuted', 'Unmuted'));
+        if (typeof window.renderChatList === 'function') {
+          window.renderChatList();
+        }
+      })
+      .catch(function () {
+        window.showToast(t('convActionFailed', 'Action failed'));
+      });
+  }
+
+  function archiveConversation(conv) {
+    var url = '/api/conversations/' + conv.id + '/archive/';
+    apiPost(url)
+      .then(function () {
+        conv.archived_at = new Date().toISOString();
+        window.showToast(t('convArchived', 'Archived'));
+        if (typeof window.fetchConversations === 'function') {
+          window.fetchConversations();
+        }
+      })
+      .catch(function () {
+        window.showToast(t('convActionFailed', 'Action failed'));
+      });
+  }
+
+  function unarchiveConversation(conv) {
+    var url = '/api/conversations/' + conv.id + '/unarchive/';
+    apiPost(url)
+      .then(function () {
+        conv.archived_at = null;
+        window.showToast(t('convUnarchived', 'Unarchived'));
+        if (typeof window.fetchConversations === 'function') {
+          window.fetchConversations();
+        }
+      })
+      .catch(function () {
+        window.showToast(t('convActionFailed', 'Action failed'));
+      });
+  }
+
+  function clearConversation(conv) {
+    var confirmed = window.confirm(t('convClearConfirm', 'Clear all messages in this chat?'));
+    if (!confirmed) return;
+    var url = '/api/conversations/' + conv.id + '/clear/';
+    apiPost(url)
+      .then(function () {
+        conv.cleared_at = new Date().toISOString();
+        window.showToast(t('convCleared', 'History cleared'));
+        // If this is the active chat, clear messages
+        if (typeof window.activeChatId !== 'undefined' && window.activeChatId === conv.id) {
+          if (typeof window.messages !== 'undefined') window.messages = [];
+          if (typeof window.renderMessages === 'function') window.renderMessages();
+        }
+      })
+      .catch(function () {
+        window.showToast(t('convActionFailed', 'Action failed'));
+      });
+  }
+
+  function deleteConversation(conv) {
+    var confirmed = window.confirm(t('convDeleteConfirm', 'Delete this conversation?'));
+    if (!confirmed) return;
+    var url = '/api/conversations/' + conv.id + '/';
+    apiDelete(url)
+      .then(function () {
+        // Remove from local state
+        if (typeof window.conversations !== 'undefined') {
+          window.conversations = window.conversations.filter(function (c) { return c.id !== conv.id; });
+          window.conversationsById = {};
+          window.conversations.forEach(function (c) { window.conversationsById[c.id] = c; });
+        }
+        if (typeof window.renderChatList === 'function') window.renderChatList();
+        // Reset active chat if needed
+        if (typeof window.activeChatId !== 'undefined' && window.activeChatId === conv.id) {
+          window.activeChatId = null;
+          var emptyState = document.getElementById('empty-state-window');
+          var activeWindow = document.getElementById('active-chat-window');
+          if (emptyState) emptyState.classList.remove('hidden');
+          if (activeWindow) activeWindow.classList.add('hidden');
+        }
+        window.showToast(t('convDeleted', 'Conversation deleted'));
+      })
+      .catch(function () {
+        window.showToast(t('convActionFailed', 'Action failed'));
+      });
+  }
+
+  function markRead(conv) {
+    var url = '/api/conversations/' + conv.id + '/read/';
+    apiPost(url)
+      .then(function () {
+        conv.unread = 0;
+        var badge = document.getElementById('unread-badge-' + conv.id);
+        if (badge) { badge.classList.add('hidden'); badge.textContent = '0'; }
+        window.showToast(t('convMarkedRead', 'Marked as read'));
+      })
+      .catch(function () {
+        window.showToast(t('convActionFailed', 'Action failed'));
+      });
+  }
+
+  function markUnread(conv) {
+    var url = '/api/conversations/' + conv.id + '/unread/';
+    apiPost(url, { unread_count: 1 })
+      .then(function () {
+        conv.unread = 1;
+        var badge = document.getElementById('unread-badge-' + conv.id);
+        if (badge) { badge.textContent = '1'; badge.classList.remove('hidden'); }
+        window.showToast(t('convMarkedUnread', 'Marked as unread'));
+      })
+      .catch(function () {
+        window.showToast(t('convActionFailed', 'Action failed'));
+      });
+  }
+
+  // --- Context menu builder ---
+
+  /**
+   * Show the conversation context menu at (x, y) viewport coordinates.
+   * Called from chat.js on right‑click of a .chat-item-btn.
+   *
+   * @param {MouseEvent|Touch} e  — event (or object with clientX / clientY)
+   * @param {object}            conv — conversation object from conversations[]
+   */
+  function showConversationMenu(e, conv) {
+    if (!conv || !window.ContextMenu) return;
+
+    var x = e.clientX || 0;
+    var y = e.clientY || 0;
+
+    var hasUnread = (conv.unread || 0) > 0;
+    var isPinned = conv.is_pinned;
+    var isMuted = conv.muted_until && new Date(conv.muted_until) > new Date();
+    var isArchived = conv.archived_at != null;
+
+    var items = [];
+
+    // Mark Read / Mark Unread
+    if (hasUnread) {
+      items.push({
+        icon: 'check-check',
+        label: t('convMarkRead', 'Mark as Read'),
+        onClick: function () { markRead(conv); },
+      });
+    } else {
+      items.push({
+        icon: 'message-circle',
+        label: t('convMarkUnread', 'Mark as Unread'),
+        onClick: function () { markUnread(conv); },
+      });
+    }
+
+    items.push({ divider: true });
+
+    // Pin / Unpin
+    if (isPinned) {
+      items.push({
+        icon: 'pin-off',
+        label: t('convUnpin', 'Unpin'),
+        onClick: function () { pinConversation(conv); },
+      });
+    } else {
+      items.push({
+        icon: 'pin',
+        label: t('convPin', 'Pin'),
+        onClick: function () { pinConversation(conv); },
+      });
+    }
+
+    // Mute sub-menu: we use a sub-label and handle it in the click
+    if (isMuted) {
+      items.push({
+        icon: 'bell',
+        label: t('convUnmute', 'Unmute'),
+        onClick: function () { unmuteConversation(conv); },
+      });
+    } else {
+      // Mute with sub-durations — show as separate items for simplicity
+      items.push({
+        icon: 'bell-off',
+        label: t('convMute1h', 'Mute for 1 hour'),
+        onClick: function () { muteConversation(conv, 60); },
+      });
+      items.push({
+        icon: 'clock',
+        label: t('convMute8h', 'Mute for 8 hours'),
+        onClick: function () { muteConversation(conv, 480); },
+      });
+      items.push({
+        icon: 'clock',
+        label: t('convMute24h', 'Mute for 24 hours'),
+        onClick: function () { muteConversation(conv, 1440); },
+      });
+      items.push({
+        icon: 'infinity',
+        label: t('convMuteForever', 'Mute forever'),
+        onClick: function () { muteConversation(conv, 10080); },
+      });
+    }
+
+    // Archive / Unarchive
+    items.push({ divider: true });
+    if (isArchived) {
+      items.push({
+        icon: 'archive-restore',
+        label: t('convUnarchive', 'Unarchive'),
+        onClick: function () { unarchiveConversation(conv); },
+      });
+    } else {
+      items.push({
+        icon: 'archive',
+        label: t('convArchive', 'Archive'),
+        onClick: function () { archiveConversation(conv); },
+      });
+    }
+
+    // Clear & Delete
+    items.push({ divider: true });
+    items.push({
+      icon: 'x-circle',
+      label: t('convClear', 'Clear History'),
+      onClick: function () { clearConversation(conv); },
+    });
+    items.push({
+      icon: 'trash-2',
+      label: t('convDelete', 'Delete Chat'),
+      danger: true,
+      onClick: function () { deleteConversation(conv); },
+    });
+
+    window.ContextMenu.show(x, y, items);
+  }
+
+  /**
+   * Re-render status icons for a single conversation item in the sidebar.
+   * Called after pin/mute/archive state changes.
+   */
+  function updateConversationStatusIcons(conv) {
+    var wrapper = document.getElementById('chat-item-wrapper-' + conv.id);
+    if (!wrapper) return;
+
+    var statusContainer = wrapper.querySelector('.conv-status-icons');
+    if (!statusContainer) {
+      // Create the container if it doesn't exist
+      var nameEl = wrapper.querySelector('.chat-item-btn h3 span');
+      if (!nameEl) return;
+      statusContainer = document.createElement('span');
+      statusContainer.className = 'conv-status-icons';
+      nameEl.parentNode.appendChild(statusContainer);
+    }
+
+    var html = '';
+    if (conv.is_pinned) {
+      html += '<i data-lucide="pin" class="conv-icon-pin"></i>';
+    }
+    var isMuted = conv.muted_until && new Date(conv.muted_until) > new Date();
+    if (isMuted) {
+      html += '<i data-lucide="bell-off" class="conv-icon-muted"></i>';
+    }
+
+    statusContainer.innerHTML = html;
+    if (window.lucide && window.lucide.createIcons) {
+      window.lucide.createIcons({ nodes: statusContainer.querySelectorAll('[data-lucide]') });
+    }
+  }
+
+  /**
+   * Refresh all conversation status icons. Call after fetchConversations().
+   */
+  function refreshAllStatusIcons() {
+    if (typeof window.conversations === 'undefined') return;
+    window.conversations.forEach(function (conv) {
+      updateConversationStatusIcons(conv);
+    });
+  }
+
+  // --- Expose to global scope ---
+  window.ConversationActions = {
+    showMenu: showConversationMenu,
+    updateStatusIcons: updateConversationStatusIcons,
+    refreshAllStatusIcons: refreshAllStatusIcons,
+    pin: pinConversation,
+    mute: muteConversation,
+    unmute: unmuteConversation,
+    archive: archiveConversation,
+    unarchive: unarchiveConversation,
+    clear: clearConversation,
+    delete: deleteConversation,
+    markRead: markRead,
+    markUnread: markUnread,
+  };
+})();

--- a/static/js/chat-message-actions.js
+++ b/static/js/chat-message-actions.js
@@ -1,0 +1,594 @@
+/**
+ * iChat Pro — Message Actions (T13)
+ *
+ * Provides context-menu handlers for message bubbles:
+ * copy, reply, forward, delete (local), recall (within 30 min), resend (failed),
+ * and select mode integration.
+ *
+ * Depends on: window.ContextMenu, global messages[], conversationsById{},
+ *              activeChatId, myUserId, showToast(), currentLanguage, getCookie(),
+ *              sendMessage(), renderMessages(), scrollToBottom()
+ */
+
+(function () {
+  'use strict';
+
+  // --- Helpers ---
+
+  function getCookie(name) {
+    var value = '; ' + document.cookie;
+    var parts = value.split('; ' + name + '=');
+    if (parts.length === 2) return parts.pop().split(';').shift();
+    return null;
+  }
+
+  function t(key, fallback) {
+    if (typeof window.translations !== 'undefined' &&
+        window.translations[currentLanguage] &&
+        window.translations[currentLanguage][key]) {
+      return window.translations[currentLanguage][key];
+    }
+    return fallback || key;
+  }
+
+  function csrfHeaders() {
+    var headers = { 'Content-Type': 'application/json' };
+    var token = getCookie('csrftoken');
+    if (token) headers['X-CSRFToken'] = token;
+    return headers;
+  }
+
+  async function apiPost(url, body) {
+    var resp = await fetch(url, {
+      method: 'POST',
+      headers: csrfHeaders(),
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!resp.ok) {
+      var errText = '';
+      try { errText = await resp.text(); } catch (_) {}
+      throw new Error('API error: ' + resp.status);
+    }
+    return resp.json().catch(function () { return null; });
+  }
+
+  async function apiDelete(url) {
+    var resp = await fetch(url, {
+      method: 'DELETE',
+      headers: csrfHeaders(),
+    });
+    if (!resp.ok) {
+      var errText = '';
+      try { errText = await resp.text(); } catch (_) {}
+      throw new Error('API error: ' + resp.status);
+    }
+    return resp.json().catch(function () { return null; });
+  }
+
+  // --- Actions ---
+
+  function copyMessageText(msg) {
+    var text = msg.text || '';
+    if (!text) {
+      window.showToast(t('msgNothingToCopy', 'Nothing to copy'));
+      return;
+    }
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () {
+        window.showToast(t('msgCopied', 'Copied'));
+      }).catch(function () {
+        // Fallback for older browsers
+        fallbackCopy(text);
+      });
+    } else {
+      fallbackCopy(text);
+    }
+  }
+
+  function fallbackCopy(text) {
+    var ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    try {
+      document.execCommand('copy');
+      window.showToast(t('msgCopied', 'Copied'));
+    } catch (e) {
+      window.showToast(t('msgCopyFailed', 'Copy failed'));
+    }
+    document.body.removeChild(ta);
+  }
+
+  function replyToMessage(msg, conv) {
+    var senderName = msg.isSelf
+      ? (currentLanguage === 'zh' ? '你' : 'You')
+      : (msg.sender_name || conv.name || 'Unknown');
+    var preview = msg.text || '';
+    if (preview.length > 80) preview = preview.substring(0, 80) + '...';
+
+    window.replyToMessage = {
+      id: msg.id,
+      sender_name: senderName,
+      text_preview: preview,
+    };
+
+    // Update the reply banner
+    renderReplyBanner();
+
+    // Focus the textarea
+    var textarea = document.getElementById('chat-input-textarea');
+    if (textarea) textarea.focus();
+  }
+
+  function renderReplyBanner() {
+    var banner = document.getElementById('reply-quote-banner');
+    if (!window.replyToMessage) {
+      if (banner) banner.style.display = 'none';
+      return;
+    }
+
+    if (!banner) {
+      // Create the banner dynamically
+      banner = document.createElement('div');
+      banner.id = 'reply-quote-banner';
+      banner.className = 'reply-quote-banner';
+      banner.innerHTML =
+        '<div class="reply-quote-preview">' +
+        '<span class="reply-quote-sender"></span>' +
+        '<span class="reply-quote-text"></span>' +
+        '</div>' +
+        '<button class="reply-quote-close" title="' + t('msgCancelReply', 'Cancel reply') + '">' +
+        '<i data-lucide="x" class="w-4 h-4"></i>' +
+        '</button>';
+
+      // Insert before the chat-input-normal-wrapper
+      var normalWrapper = document.getElementById('chat-input-normal-wrapper');
+      if (normalWrapper && normalWrapper.parentNode) {
+        normalWrapper.parentNode.insertBefore(banner, normalWrapper);
+      }
+
+      // Wire close button
+      var closeBtn = banner.querySelector('.reply-quote-close');
+      if (closeBtn) {
+        closeBtn.addEventListener('click', function (e) {
+          e.preventDefault();
+          cancelReply();
+        });
+      }
+
+      // Wire click-to-scroll
+      banner.addEventListener('click', function (e) {
+        if (e.target.closest('.reply-quote-close')) return;
+        if (window.replyToMessage && window.replyToMessage.id) {
+          scrollToMessage(window.replyToMessage.id);
+        }
+      });
+    }
+
+    var r = window.replyToMessage;
+    var senderEl = banner.querySelector('.reply-quote-sender');
+    var textEl = banner.querySelector('.reply-quote-text');
+    if (senderEl) senderEl.textContent = r.sender_name + ': ';
+    if (textEl) textEl.textContent = r.text_preview;
+    banner.style.display = 'flex';
+
+    // Re-render icons
+    if (window.lucide && window.lucide.createIcons) {
+      window.lucide.createIcons({ nodes: banner.querySelectorAll('[data-lucide]') });
+    }
+  }
+
+  function cancelReply() {
+    window.replyToMessage = null;
+    renderReplyBanner();
+  }
+
+  function scrollToMessage(msgId) {
+    var bubble = document.querySelector('.message-bubble-custom[data-message-id="' + msgId + '"]');
+    if (!bubble) {
+      bubble = document.querySelector('[data-message-id="' + msgId + '"]');
+    }
+    if (bubble) {
+      bubble.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      bubble.style.boxShadow = '0 0 0 2px var(--color-primary)';
+      setTimeout(function () { bubble.style.boxShadow = ''; }, 2000);
+    }
+  }
+
+  function forwardMessage(msg) {
+    // For now: show a contact picker by reusing existing contacts list
+    var convs = window.conversations || [];
+    var targets = convs.filter(function (c) {
+      return c.type === 'single' && c.id !== window.activeChatId;
+    });
+
+    if (targets.length === 0) {
+      window.showToast(t('msgNoForwardTargets', 'No conversations to forward to'));
+      return;
+    }
+
+    // Build a simple picker modal
+    var modal = document.getElementById('forward-picker-modal');
+    if (!modal) {
+      modal = createForwardModal();
+    }
+
+    var listEl = modal.querySelector('.forward-picker-list');
+    listEl.innerHTML = '';
+    targets.forEach(function (target) {
+      var item = document.createElement('button');
+      var color = /^#[0-9a-fA-F]{6}$/.test(target.avatar_color || '') ? target.avatar_color : '#5c6bc0';
+      item.className = 'flex items-center gap-3 w-full px-3 py-2.5 rounded-lg hover:bg-bgSearch transition-colors text-left border-none bg-transparent cursor-pointer';
+      item.innerHTML =
+        '<div class="w-9 h-9 rounded-full text-white flex items-center justify-center font-bold text-xs flex-shrink-0" style="background-color:' + color + '">' +
+        (target.initials || '??') +
+        '</div>' +
+        '<span class="text-sm font-medium text-textMain truncate">' + (target.name || 'Unknown') + '</span>';
+      item.addEventListener('click', function () {
+        modal.classList.remove('flex');
+        modal.classList.add('hidden');
+        doForward(msg, target);
+      });
+      listEl.appendChild(item);
+    });
+
+    modal.classList.remove('hidden');
+    modal.classList.add('flex');
+  }
+
+  function createForwardModal() {
+    var modal = document.createElement('div');
+    modal.id = 'forward-picker-modal';
+    modal.className = 'hidden fixed inset-0 bg-black/55 backdrop-blur-[2px] z-[200] items-center justify-center p-4';
+    modal.innerHTML =
+      '<div class="bg-bgSidebar border border-borderColor rounded-custom-lg shadow-2xl w-full max-w-[380px] max-h-[60vh] flex flex-col">' +
+      '<div class="flex items-center justify-between px-5 py-4 border-b border-borderColor">' +
+      '<h3 class="text-base font-bold text-textMain">' + t('msgForwardTitle', 'Forward to...') + '</h3>' +
+      '<button class="p-1.5 rounded-full hover:bg-bgSearch text-textSecondary transition-colors forward-picker-close">' +
+      '<i data-lucide="x" class="w-5 h-5"></i>' +
+      '</button>' +
+      '</div>' +
+      '<div class="flex-1 overflow-y-auto p-2 forward-picker-list"></div>' +
+      '</div>';
+    document.body.appendChild(modal);
+
+    // Wire close
+    modal.addEventListener('click', function (e) {
+      if (e.target === modal || e.target.closest('.forward-picker-close')) {
+        modal.classList.remove('flex');
+        modal.classList.add('hidden');
+      }
+    });
+
+    if (window.lucide && window.lucide.createIcons) {
+      window.lucide.createIcons({ nodes: modal.querySelectorAll('[data-lucide]') });
+    }
+
+    return modal;
+  }
+
+  async function doForward(msg, targetConv) {
+    var convId = window.activeChatId;
+    var plaintext = msg.text || '';
+    if (!plaintext) {
+      window.showToast(t('msgNothingToCopy', 'Nothing to forward'));
+      return;
+    }
+
+    try {
+      var clientMsgId = 'fwd-' + Date.now() + '-' + Math.random().toString(16).slice(2);
+      var payload = {
+        original_message_id: msg.id,
+        original_conversation_id: convId,
+        client_message_id: clientMsgId,
+        message_type: 'text',
+      };
+
+      if (targetConv.type === 'group') {
+        // Group target: encrypt for each member
+        if (!window.iChatGroupE2EE || !window.iChatGroupE2EE.encryptGroupMessage) {
+          throw new Error('Group E2EE module not loaded');
+        }
+        var memberIds = typeof window.fetchGroupMemberIds === 'function'
+          ? await window.fetchGroupMemberIds(targetConv.id)
+          : [];
+        var result = await window.iChatGroupE2EE.encryptGroupMessage({
+          plaintext: plaintext,
+          groupId: targetConv.id,
+          membershipVersion: targetConv.membership_version || 1,
+          memberIds: memberIds,
+        });
+        payload.algorithm = result.algorithm;
+        payload.sender_key_version = result.sender_key_version;
+        payload.membership_version = result.membership_version;
+        // Enrich each recipient with fields the REST forward view expects:
+        // receiver_id (not user_id), sender_key_version, algorithm
+        payload.recipients = result.recipients.map(function(r) {
+          return {
+            receiver_id: r.user_id || r.receiver_id,
+            ciphertext: r.ciphertext,
+            nonce: r.nonce,
+            auth_tag: r.auth_tag,
+            algorithm: result.algorithm,
+            sender_key_version: result.sender_key_version,
+            receiver_key_version: r.receiver_key_version,
+          };
+        });
+      } else {
+        // Private chat target: encrypt for the single peer
+        if (!window.iChatPrivateE2EE || !window.iChatPrivateE2EE.encryptPrivateMessage || !targetConv.peer_id) {
+          throw new Error('Private E2EE module or peer info missing');
+        }
+        payload.peer_id = targetConv.peer_id;
+        var encResult = await window.iChatPrivateE2EE.encryptPrivateMessage({
+          plaintext: plaintext,
+          conversationId: targetConv.id,
+          receiverId: targetConv.peer_id,
+        });
+        payload.ciphertext = encResult.ciphertext;
+        payload.nonce = encResult.nonce;
+        payload.auth_tag = encResult.auth_tag;
+        payload.algorithm = encResult.algorithm;
+        payload.sender_key_version = encResult.sender_key_version;
+        payload.receiver_key_version = encResult.receiver_key_version;
+      }
+
+      await apiPost('/api/conversations/' + targetConv.id + '/messages/forward/', payload);
+      window.showToast(t('msgForwarded', 'Forwarded'));
+    } catch (e) {
+      console.error('Forward failed:', e);
+      window.showToast(t('msgForwardFailed', 'Forward failed'));
+    }
+  }
+
+  function deleteMessage(msg) {
+    var convId = window.activeChatId;
+    if (!convId) return;
+
+    apiDelete('/api/conversations/' + convId + '/messages/' + msg.id + '/')
+      .then(function () {
+        // Mark deleted locally
+        msg.isDeleted = true;
+        msg.text = t('msgDeleted', 'message deleted');
+        msg.isSystem = true;
+        if (typeof window.renderMessages === 'function') window.renderMessages();
+        window.showToast(t('msgDeletedToast', 'Message deleted'));
+      })
+      .catch(function () {
+        window.showToast(t('msgActionFailed', 'Action failed'));
+      });
+  }
+
+  function recallMessage(msg) {
+    var convId = window.activeChatId;
+    if (!convId) return;
+
+    apiPost('/api/conversations/' + convId + '/messages/' + msg.id + '/recall/')
+      .then(function () {
+        msg.isRecalled = true;
+        msg.text = msg.isSelf
+          ? t('msgYouRecalled', 'You recalled a message')
+          : t('msgRecalled', 'message recalled');
+        msg.isSystem = true;
+        if (typeof window.renderMessages === 'function') window.renderMessages();
+        window.showToast(t('msgRecalledToast', 'Message recalled'));
+      })
+      .catch(function () {
+        window.showToast(t('msgRecallFailed', 'Recall failed'));
+      });
+  }
+
+  function resendMessage(msg) {
+    // Remove the failed message and retry
+    var msgs = window.messages || [];
+    var idx = msgs.indexOf(msg);
+    if (idx >= 0) msgs.splice(idx, 1);
+
+    // Fill textarea and send
+    var textarea = document.getElementById('chat-input-textarea');
+    if (textarea && msg.text) {
+      textarea.value = msg.text;
+      if (typeof window.adjustTextareaHeight === 'function') {
+        window.adjustTextareaHeight(textarea);
+      }
+      if (typeof window.sendMessage === 'function') {
+        window.sendMessage();
+      }
+    }
+    if (typeof window.renderMessages === 'function') window.renderMessages();
+  }
+
+  function selectMessage(msg) {
+    // Enter select mode and toggle this message
+    if (typeof window.isSelectingMessages !== 'undefined' && !window.isSelectingMessages) {
+      if (typeof window.triggerSelectMessagesAction === 'function') {
+        window.triggerSelectMessagesAction();
+      }
+    }
+    if (typeof window.selectedMessageIds !== 'undefined' && typeof window.toggleMessageSelection === 'function') {
+      window.toggleMessageSelection(msg.id);
+    }
+  }
+
+  // --- Context menu builder ---
+
+  /**
+   * Show the message context menu at (x, y) viewport coordinates.
+   * Called on right‑click or long‑press of a message bubble.
+   *
+   * @param {MouseEvent|Touch} e   — event (clientX / clientY)
+   * @param {object}            msg  — message object from messages[]
+   * @param {object}            conv — active conversation
+   */
+  function showMessageMenu(e, msg, conv) {
+    if (!msg || !window.ContextMenu) return;
+
+    var x = e.clientX || 0;
+    var y = e.clientY || 0;
+
+    var isSelf = msg.isSelf;
+    var isSystem = msg.isSystem;
+    var isRecalled = msg.isRecalled;
+    var isFailed = msg.status === 'failed' || msg.client_status === 'failed';
+
+    // System / recalled messages have very limited menu
+    if (isSystem || isRecalled) {
+      if (!msg.text) return;
+      window.ContextMenu.show(x, y, [
+        {
+          icon: 'copy',
+          label: t('msgCopy', 'Copy'),
+          onClick: function () { copyMessageText(msg); },
+        },
+      ]);
+      return;
+    }
+
+    var items = [];
+
+    // Copy
+    items.push({
+      icon: 'copy',
+      label: t('msgCopy', 'Copy'),
+      onClick: function () { copyMessageText(msg); },
+    });
+
+    // Reply
+    items.push({
+      icon: 'corner-up-left',
+      label: t('msgReply', 'Reply'),
+      onClick: function () { replyToMessage(msg, conv); },
+    });
+
+    // Forward
+    items.push({
+      icon: 'corner-up-right',
+      label: t('msgForward', 'Forward'),
+      onClick: function () { forwardMessage(msg); },
+    });
+
+    items.push({ divider: true });
+
+    // Select
+    items.push({
+      icon: 'check-circle',
+      label: t('msgSelect', 'Select'),
+      onClick: function () { selectMessage(msg); },
+    });
+
+    items.push({ divider: true });
+
+    // Delete (always available for own messages, local only)
+    items.push({
+      icon: 'trash-2',
+      label: t('msgDelete', 'Delete'),
+      danger: true,
+      onClick: function () { deleteMessage(msg); },
+    });
+
+    // Recall (own messages within 30 minutes)
+    if (isSelf && !isFailed) {
+      var msgTime = msg.created_at ? new Date(msg.created_at).getTime() : 0;
+      var now = Date.now();
+      var within30min = !msg.created_at || (now - msgTime) < 30 * 60 * 1000;
+      if (within30min) {
+        items.push({
+          icon: 'rotate-ccw',
+          label: t('msgRecall', 'Recall'),
+          danger: true,
+          onClick: function () { recallMessage(msg); },
+        });
+      }
+    }
+
+    // Resend (failed messages only)
+    if (isFailed && isSelf) {
+      items.push({
+        icon: 'refresh-cw',
+        label: t('msgResend', 'Resend'),
+        onClick: function () { resendMessage(msg); },
+      });
+    }
+
+    window.ContextMenu.show(x, y, items);
+  }
+
+  // --- Long-press support (mobile) ---
+
+  var longPressTimer = null;
+  var longPressTarget = null;
+
+  function initLongPress() {
+    var container = document.getElementById('message-history-container');
+    if (!container) return;
+
+    container.addEventListener('touchstart', function (e) {
+      var bubble = e.target.closest('.message-bubble-custom');
+      if (!bubble) return;
+
+      longPressTarget = bubble;
+      longPressTimer = setTimeout(function () {
+        var msgId = longPressTarget.getAttribute('data-message-id');
+        if (!msgId) return;
+        var msg = findMessageById(msgId);
+        var conv = window.conversationsById && window.activeChatId
+          ? window.conversationsById[window.activeChatId]
+          : null;
+        if (msg) {
+          // Use last touch position
+          var touch = e.touches[0] || e.changedTouches[0];
+          showMessageMenu(
+            { clientX: touch ? touch.clientX : 100, clientY: touch ? touch.clientY : 100 },
+            msg,
+            conv
+          );
+        }
+        longPressTarget = null;
+      }, 500);
+    }, { passive: false });
+
+    container.addEventListener('touchend', function () {
+      clearTimeout(longPressTimer);
+      longPressTarget = null;
+    });
+
+    container.addEventListener('touchmove', function () {
+      clearTimeout(longPressTimer);
+      longPressTarget = null;
+    });
+  }
+
+  function findMessageById(msgId) {
+    var msgs = window.messages || [];
+    for (var i = 0; i < msgs.length; i++) {
+      if (msgs[i].id === msgId || String(msgs[i].id) === String(msgId)) {
+        return msgs[i];
+      }
+    }
+    return null;
+  }
+
+  // --- Expose ---
+
+  window.MessageActions = {
+    showMenu: showMessageMenu,
+    copyText: copyMessageText,
+    reply: replyToMessage,
+    forward: forwardMessage,
+    delete: deleteMessage,
+    recall: recallMessage,
+    resend: resendMessage,
+    select: selectMessage,
+    cancelReply: cancelReply,
+    renderReplyBanner: renderReplyBanner,
+  };
+
+  // Initialize long-press when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initLongPress);
+  } else {
+    initLongPress();
+  }
+})();

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -29,6 +29,41 @@ let replyToMessage = null;          // { id, sender_name, text_preview } for rep
 let typingUsers = {};              // Map: conversationId → { userId, timeoutId }
 let connectionStatus = 'connecting'; // 'connected' | 'connecting' | 'disconnected'
 
+// Expose state to window for cross-module access (T12/T13/T14 modules)
+// — readable via getters that always return the current value
+// — writable where new modules need to update state (clear/delete/reset)
+Object.defineProperty(window, 'conversations', {
+  get() { return conversations; },
+  set(v) { conversations = v; },
+  enumerable: true, configurable: true
+});
+Object.defineProperty(window, 'conversationsById', {
+  get() { return conversationsById; },
+  set(v) { conversationsById = v; },
+  enumerable: true, configurable: true
+});
+Object.defineProperty(window, 'activeChatId', {
+  get() { return activeChatId; },
+  set(v) { activeChatId = v; },
+  enumerable: true, configurable: true
+});
+Object.defineProperty(window, 'messages', {
+  get() { return messages; },
+  set(v) { messages = v; },
+  enumerable: true, configurable: true
+});
+Object.defineProperty(window, 'myUserId', { get() { return myUserId; }, enumerable: true, configurable: true });
+Object.defineProperty(window, 'currentLanguage', { get() { return currentLanguage; }, enumerable: true, configurable: true });
+Object.defineProperty(window, 'isSelectingMessages', { get() { return isSelectingMessages; }, enumerable: true, configurable: true });
+Object.defineProperty(window, 'selectedMessageIds', { get() { return selectedMessageIds; }, enumerable: true, configurable: true });
+Object.defineProperty(window, 'wsClient', { get() { return wsClient; }, enumerable: true, configurable: true });
+Object.defineProperty(window, 'replyToMessage', {
+  get() { return replyToMessage; },
+  set(v) { replyToMessage = v; },
+  enumerable: true, configurable: true
+});
+Object.defineProperty(window, 'typingUsers', { get() { return typingUsers; }, enumerable: true, configurable: true });
+
 function formatClockTime(date = new Date()) {
   return date.toLocaleTimeString([], {
     hour: "2-digit",
@@ -1525,7 +1560,7 @@ async function sendMessage() {
               algorithm: result.algorithm,
               client_message_id: clientMsgId,
               recipients: result.recipients,
-              reply_to: tempMsg.reply_to || undefined
+              reply_to_message_id: tempMsg.reply_to || undefined
             }
           })) {
             throw new Error("WebSocket is not connected.");
@@ -1547,7 +1582,7 @@ async function sendMessage() {
             receiver_key_version: result.receiver_key_version,
             client_message_id: clientMsgId,
             message_type: "text",
-            reply_to: tempMsg.reply_to || undefined,
+            reply_to_message_id: tempMsg.reply_to || undefined,
           })
         });
         handleMessageAccepted({ data: accepted });
@@ -1989,6 +2024,29 @@ function setupEventListeners() {
         e.preventDefault();
         sendMessage();
       }
+    });
+    // T14: Send typing.start / typing.stop via WebSocket
+    let typingTimer = null;
+    let typingSent = false;
+    chatInput.addEventListener("input", () => {
+      if (!activeChatId || !wsClient || !wsClient.sendPayload) return;
+      if (!typingSent) {
+        wsClient.sendPayload({
+          event: "typing.start",
+          data: { conversation_id: activeChatId }
+        });
+        typingSent = true;
+      }
+      clearTimeout(typingTimer);
+      typingTimer = setTimeout(() => {
+        if (wsClient && wsClient.sendPayload) {
+          wsClient.sendPayload({
+            event: "typing.stop",
+            data: { conversation_id: activeChatId }
+          });
+        }
+        typingSent = false;
+      }, 2500);
     });
   }
 
@@ -3990,8 +4048,8 @@ window.confirmDeleteChat = async function() {
   const chatIdToDelete = activeChatId;
   
   try {
-    const response = await fetch(`/api/conversations/${chatIdToDelete}/hide/`, {
-      method: 'POST',
+    const response = await fetch(`/api/conversations/${chatIdToDelete}/`, {
+      method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
         'X-CSRFToken': getCookie('csrftoken') || ''

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -20,7 +20,14 @@ let e2eeKeyReady = true;
 let e2eeKeyError = null;
 let groupMembersByConversation = {};
 let fingerprintCacheByUserId = {};
+let contactKeyStatusCacheByUserId = {};
+let keyTrustListCache = null;
 let detailsPanelRequestId = 0;
+let currentSearchTab = 'chats';     // Active search type tab
+let searchDebounceTimer = null;    // Debounce timer for search input
+let replyToMessage = null;          // { id, sender_name, text_preview } for reply quoting
+let typingUsers = {};              // Map: conversationId → { userId, timeoutId }
+let connectionStatus = 'connecting'; // 'connected' | 'connecting' | 'disconnected'
 
 function formatClockTime(date = new Date()) {
   return date.toLocaleTimeString([], {
@@ -368,6 +375,33 @@ function appendChatItemToSidebar(conv) {
 
   chatListContainer.appendChild(wrapper);
   lucide.createIcons();
+
+  // Wire right-click context menu on this conversation item
+  const btn = wrapper.querySelector('.chat-item-btn');
+  if (btn) {
+    btn.addEventListener('contextmenu', function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (typeof ConversationActions !== 'undefined' && ConversationActions.showMenu) {
+        ConversationActions.showMenu(e, conv);
+      }
+    });
+  }
+
+  // Add avatar class for online indicator
+  const avatarDiv = wrapper.querySelector('.w-12.h-12.rounded-full');
+  if (avatarDiv) {
+    avatarDiv.classList.add('avatar');
+    // Check if peer is online (for private chats)
+    if (conv.type === 'single' && conv.is_online) {
+      avatarDiv.classList.add('online');
+    }
+  }
+
+  // Add status icons (pin, mute) after insertion
+  if (typeof ConversationActions !== 'undefined' && ConversationActions.updateStatusIcons) {
+    ConversationActions.updateStatusIcons(conv);
+  }
 }
 
 function updateSidebarPreview(conv, text, time) {
@@ -517,6 +551,107 @@ async function fetchPeerFingerprint(userId) {
   }
 }
 
+async function fetchContactKeyStatus(userId, { force = false } = {}) {
+  if (!userId) return null;
+  if (!force && contactKeyStatusCacheByUserId[userId] !== undefined) {
+    return contactKeyStatusCacheByUserId[userId];
+  }
+  try {
+    const data = await apiFetch(`/api/keys/contacts/${userId}/fingerprints/`);
+    contactKeyStatusCacheByUserId[userId] = data;
+    return data;
+  } catch (err) {
+    contactKeyStatusCacheByUserId[userId] = null;
+    return null;
+  }
+}
+
+function getActiveKeyStatus(contactStatus) {
+  if (!contactStatus || !contactStatus.active_key) return null;
+  const active = contactStatus.active_key;
+  const keys = Array.isArray(contactStatus.keys) ? contactStatus.keys : [];
+  const matched = keys.find(key => key.key_fingerprint === active.key_fingerprint);
+  return {
+    ...active,
+    trust_status: matched ? matched.trust_status : 'untrusted'
+  };
+}
+
+function contactKeyHasChanged(contactStatus) {
+  if (!contactStatus || !contactStatus.active_key || !Array.isArray(contactStatus.keys)) return false;
+  return contactStatus.keys.some(key =>
+    key.trust_status &&
+    key.trust_status !== 'untrusted' &&
+    key.key_fingerprint !== contactStatus.active_key.key_fingerprint
+  );
+}
+
+function trustStatusMeta(status, keyChanged = false) {
+  if (keyChanged) {
+    return {
+      className: 'font-semibold text-red-500 flex items-center space-x-1',
+      icon: 'shield-alert',
+      iconClass: 'text-red-500',
+      label: currentLanguage === 'zh' ? '密钥已变更' : 'Key changed'
+    };
+  }
+  if (status === 'missing') {
+    return {
+      className: 'font-semibold text-red-500 flex items-center space-x-1',
+      icon: 'shield-alert',
+      iconClass: 'text-red-500',
+      label: currentLanguage === 'zh' ? '缺少公钥' : 'No public key'
+    };
+  }
+  if (status === 'trusted' || status === 'verified') {
+    return {
+      className: 'font-semibold text-emerald-500 flex items-center space-x-1',
+      icon: 'shield-check',
+      iconClass: 'text-emerald-500',
+      label: currentLanguage === 'zh' ? '已验证' : 'Verified'
+    };
+  }
+  return {
+    className: 'font-semibold text-amber-500 flex items-center space-x-1',
+    icon: 'shield-question',
+    iconClass: 'text-amber-500',
+    label: currentLanguage === 'zh' ? '未验证' : 'Unverified'
+  };
+}
+
+function setVerificationStatus(el, status, keyChanged = false) {
+  if (!el) return;
+  const meta = trustStatusMeta(status, keyChanged);
+  el.className = meta.className;
+  el.innerHTML = `<i data-lucide="${meta.icon}" class="w-3.5 h-3.5 mr-0.5 inline-block ${meta.iconClass}"></i><span>${escapeHtml(meta.label)}</span>`;
+}
+
+async function setContactKeyTrust(userId, trustStatus = 'verified') {
+  const data = await apiFetch(`/api/keys/contacts/${userId}/trust/`, {
+    method: 'POST',
+    body: JSON.stringify({ trust_status: trustStatus })
+  });
+  delete contactKeyStatusCacheByUserId[userId];
+  keyTrustListCache = null;
+  fingerprintCacheByUserId[userId] = null;
+  const refreshed = await fetchContactKeyStatus(userId, { force: true });
+  const active = getActiveKeyStatus(refreshed);
+  if (active && window.iChatPrivateE2EE && window.iChatPrivateE2EE.trustPeerKey) {
+    window.iChatPrivateE2EE.trustPeerKey(active);
+  }
+  return { data, refreshed };
+}
+
+async function clearContactKeyTrust(userId) {
+  const data = await apiFetch(`/api/keys/contacts/${userId}/trust/`, { method: 'DELETE' });
+  delete contactKeyStatusCacheByUserId[userId];
+  keyTrustListCache = null;
+  if (window.iChatPrivateE2EE && window.iChatPrivateE2EE.forgetPeerKey) {
+    window.iChatPrivateE2EE.forgetPeerKey(userId);
+  }
+  return data;
+}
+
 function formatFingerprint(value) {
   if (!value) {
     return currentLanguage === 'zh' ? '联系人尚未上传公钥' : 'Contact has not uploaded a public key';
@@ -586,6 +721,7 @@ function connectWebSocket() {
       socket = new WebSocket(url);
       socket.addEventListener('open', () => {
         logToCryptoConsole('[WebSocket] Connected');
+        updateConnectionBadge('connected');
       });
       socket.addEventListener('message', (event) => {
         try {
@@ -595,6 +731,7 @@ function connectWebSocket() {
         }
       });
       socket.addEventListener('close', (event) => {
+        updateConnectionBadge('disconnected');
         logToCryptoConsole(`[WebSocket] Disconnected: ${event.reason || event.code}`);
         window.clearTimeout(reconnectTimer);
         reconnectTimer = window.setTimeout(() => wsClient.connect(), 1500);
@@ -613,6 +750,7 @@ function handleIncomingMessage(data) {
 
   if (event === 'connection.ready') {
     logToCryptoConsole(`[WebSocket] Ready for user ${data.data?.user_id || myUserId}`);
+    updateConnectionBadge('connected');
   } else if (event === 'message.single.new') {
     handlePrivateMessageReceived(data);
   } else if (event === 'message.single.accepted') {
@@ -625,6 +763,14 @@ function handleIncomingMessage(data) {
     handleMessageAccepted(data);
   } else if (event === 'group.members.changed') {
     fetchConversations();
+  } else if (event === 'typing' || event === 'typing.indicator') {
+    handleTypingEvent(data);
+  } else if (event === 'presence.updated') {
+    handlePresenceEvent(data);
+  } else if (event === 'message.recalled') {
+    handleMessageRecalled(data);
+  } else if (event === 'message.deleted') {
+    handleMessageDeleted(data);
   } else if (event === 'error') {
     logToCryptoConsole(`[WebSocket Error] ${data.data?.message || 'Unknown error'}`);
   } else {
@@ -772,6 +918,31 @@ function handleMessageStatusUpdate(data) {
   }
 }
 
+function handleMessageRecalled(data) {
+  const payload = data.data || data;
+  const msg = messages.find(m => m.id === payload.message_id);
+  if (msg) {
+    msg.isRecalled = true;
+    msg.isSystem = true;
+    msg.text = payload.sender_id === myUserId
+      ? (currentLanguage === 'zh' ? '你撤回了一条消息' : 'You recalled a message')
+      : (currentLanguage === 'zh' ? '消息已被撤回' : 'message recalled');
+    renderMessages();
+  }
+}
+
+function handleMessageDeleted(data) {
+  const payload = data.data || data;
+  // Per-user deletion notification — remove from local view if active
+  const msg = messages.find(m => m.id === payload.message_id);
+  if (msg) {
+    msg.isDeleted = true;
+    msg.isSystem = true;
+    msg.text = currentLanguage === 'zh' ? '消息已删除' : 'message deleted';
+    renderMessages();
+  }
+}
+
 function handleMessageAccepted(data) {
   const payload = data.data || data;
   const tempId = payload.client_message_id;
@@ -827,6 +998,206 @@ async function deriveActiveSessionKey(convId) {
     console.error('ECDH session key derivation failed:', err);
     logToCryptoConsole(`[ECDH Error] Derivation failed: ${err.message}`);
     sessionKeys[convId] = null;
+  }
+}
+
+// ============================================================================
+// T14 Helper: send read receipts for undelivered messages in active chat
+// ============================================================================
+function sendReadReceipts(conv) {
+  if (!wsClient || !wsClient.sendPayload) return;
+  messages.forEach(function(msg) {
+    if (msg.isSelf) return; // don't send receipts for own messages
+    if (msg.status === 'delivered' || msg.status === 'sent' || msg.status === 'received') {
+      wsClient.sendPayload({
+        event: 'message.receipt.update',
+        data: {
+          conversation_type: conv.type === 'group' ? 'group' : 'single',
+          message_id: msg.id,
+          status: 'read'
+        }
+      });
+    }
+  });
+}
+
+// ============================================================================
+// T14 Helper: update chat header with online/last-seen presence
+// ============================================================================
+function updateHeaderPresence(conv) {
+  var statusEl = document.getElementById('chat-header-status');
+  if (!statusEl) return;
+
+  // Check typing indicator first
+  if (typingUsers[conv.id]) {
+    var typingUserIds = typingUsers[conv.id];
+    if (Object.keys(typingUserIds).length > 0) {
+      var typingHtml = '<span class="text-brand-light dark:text-brand-dark font-medium">' +
+        (currentLanguage === 'zh' ? '正在输入' : 'Typing') +
+        '</span><span class="typing-indicator-dots">' +
+        '<span class="typing-dot"></span><span class="typing-dot"></span><span class="typing-dot"></span></span>';
+      statusEl.innerHTML = typingHtml;
+      return;
+    }
+  }
+
+  if (conv.type === 'group') {
+    statusEl.textContent = currentLanguage === 'zh'
+      ? (conv.member_count || 0) + ' 位成员'
+      : (conv.member_count || 0) + ' members';
+    return;
+  }
+
+  // Private chat: check presence
+  if (conv.is_online) {
+    statusEl.innerHTML = '<span class="inline-block w-2 h-2 rounded-full bg-green-500 mr-1.5 align-middle"></span>' +
+      (currentLanguage === 'zh' ? '在线' : 'Online');
+  } else if (conv.last_seen) {
+    var lastSeen = new Date(conv.last_seen);
+    var now = new Date();
+    var diffMs = now - lastSeen;
+    var diffMin = Math.floor(diffMs / 60000);
+    var diffHours = Math.floor(diffMs / 3600000);
+    var diffDays = Math.floor(diffMs / 86400000);
+
+    var timeStr = lastSeen.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    var text;
+    if (diffMin < 1) {
+      text = currentLanguage === 'zh' ? '刚刚在线' : 'Last seen just now';
+    } else if (diffMin < 60) {
+      text = (currentLanguage === 'zh' ? '最后上线 ' : 'Last seen ') + diffMin + (currentLanguage === 'zh' ? ' 分钟前' : ' min ago');
+    } else if (diffHours < 6) {
+      text = (currentLanguage === 'zh' ? '最后上线 ' : 'Last seen ') + diffHours + (currentLanguage === 'zh' ? ' 小时前' : ' hours ago');
+    } else if (diffDays === 0) {
+      text = (currentLanguage === 'zh' ? '最后上线今天 ' : 'Last seen today at ') + timeStr;
+    } else if (diffDays === 1) {
+      text = (currentLanguage === 'zh' ? '最后上线昨天 ' : 'Last seen yesterday at ') + timeStr;
+    } else {
+      var dateStr = lastSeen.toLocaleDateString([], { month: 'short', day: 'numeric' });
+      text = (currentLanguage === 'zh' ? '最后上线 ' : 'Last seen ') + dateStr;
+    }
+    statusEl.textContent = text;
+  } else {
+    statusEl.textContent = currentLanguage === 'zh' ? '联系人' : 'Contact';
+  }
+}
+
+// ============================================================================
+// T14 Helper: update WebSocket connection status badge
+// ============================================================================
+function updateConnectionBadge(status) {
+  connectionStatus = status;
+  var badge = document.getElementById('connection-status-badge');
+
+  if (!badge) {
+    // Create the badge dynamically
+    badge = document.createElement('div');
+    badge.id = 'connection-status-badge';
+    badge.className = 'connection-badge';
+    document.body.appendChild(badge);
+  }
+
+  var icon, text, className;
+  if (status === 'connected') {
+    icon = 'wifi';
+    text = currentLanguage === 'zh' ? '已连接' : 'Connected';
+    className = 'connection-badge connected visible';
+    // Auto-hide connected badge after 3s
+    setTimeout(function() {
+      if (connectionStatus === 'connected') {
+        badge.classList.remove('visible');
+      }
+    }, 3000);
+  } else if (status === 'connecting') {
+    icon = 'wifi';
+    text = currentLanguage === 'zh' ? '重连中...' : 'Reconnecting...';
+    className = 'connection-badge reconnecting visible';
+  } else {
+    icon = 'wifi-off';
+    text = currentLanguage === 'zh' ? '已断开' : 'Disconnected';
+    className = 'connection-badge disconnected visible';
+  }
+
+  badge.className = className;
+  badge.innerHTML = '<i data-lucide="' + icon + '" class="w-3.5 h-3.5"></i><span>' + text + '</span>';
+  if (window.lucide) window.lucide.createIcons({ nodes: badge.querySelectorAll('[data-lucide]') });
+}
+
+// ============================================================================
+// T14 Helper: handle typing indicator from WebSocket events
+// ============================================================================
+function handleTypingEvent(data) {
+  var payload = data.data || data;
+  var convId = payload.conversation_id;
+  var userId = payload.user_id;
+  var action = payload.action; // 'typing' or 'stop'
+
+  if (!typingUsers[convId]) typingUsers[convId] = {};
+
+  if (action === 'typing') {
+    // Set typing
+    typingUsers[convId][userId] = true;
+    // Auto-clear after 4 seconds
+    if (typingUsers[convId]['_timeout_' + userId]) {
+      clearTimeout(typingUsers[convId]['_timeout_' + userId]);
+    }
+    typingUsers[convId]['_timeout_' + userId] = setTimeout(function() {
+      delete typingUsers[convId][userId];
+      delete typingUsers[convId]['_timeout_' + userId];
+      if (Object.keys(typingUsers[convId]).filter(function(k) { return k.indexOf('_timeout_') !== 0; }).length === 0) {
+        // Update header to show normal status
+        if (activeChatId === convId) {
+          var conv = conversationsById[convId];
+          if (conv) updateHeaderPresence(conv);
+        }
+      }
+    }, 4000);
+  } else if (action === 'stop') {
+    delete typingUsers[convId][userId];
+    if (typingUsers[convId]['_timeout_' + userId]) {
+      clearTimeout(typingUsers[convId]['_timeout_' + userId]);
+      delete typingUsers[convId]['_timeout_' + userId];
+    }
+  }
+
+  // Update header if this is the active conversation
+  if (activeChatId === convId) {
+    var conv = conversationsById[convId];
+    if (conv) updateHeaderPresence(conv);
+  }
+}
+
+// ============================================================================
+// T14 Helper: handle presence update from WebSocket
+// ============================================================================
+function handlePresenceEvent(data) {
+  var payload = data.data || data;
+  var userId = payload.user_id;
+
+  // Update all conversations involving this user
+  for (var convId in conversationsById) {
+    var conv = conversationsById[convId];
+    if (conv.type === 'single' && conv.peer_id === userId) {
+      conv.is_online = payload.is_online;
+      conv.last_seen = payload.last_seen;
+      conv.status_text = payload.status;
+
+      // Update online dot in sidebar
+      var item = document.getElementById('chat-item-' + conv.id);
+      var avatar = item ? item.querySelector('.avatar') : null;
+      if (avatar) {
+        if (payload.is_online) {
+          avatar.classList.add('online');
+        } else {
+          avatar.classList.remove('online');
+        }
+      }
+
+      // Update header if this is the active chat
+      if (activeChatId === conv.id) {
+        updateHeaderPresence(conv);
+      }
+    }
   }
 }
 
@@ -909,6 +1280,21 @@ async function selectChat(chatId) {
   renderMessages();
   scrollToBottom();
   updateDetailsPanel(conv);
+
+  // Send read receipts for any undelivered messages
+  sendReadReceipts(conv);
+
+  // Mark conversation as read via REST API
+  fetch('/api/conversations/' + activeChatId + '/read/', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRFToken': getCookie('csrftoken') || ''
+    }
+  }).catch(function() {});
+
+  // Update header with presence data
+  updateHeaderPresence(conv);
 }
 
 async function updateDetailsPanel(conv) {
@@ -944,20 +1330,16 @@ async function updateDetailsPanel(conv) {
     }
 
     if (conv.type === "single" && conv.peer_id) {
-      const fingerprint = await fetchPeerFingerprint(conv.peer_id);
+      const contactStatus = await fetchContactKeyStatus(conv.peer_id);
       if (requestId !== detailsPanelRequestId) return;
+      const activeKey = getActiveKeyStatus(contactStatus);
+      const keyChanged = contactKeyHasChanged(contactStatus);
       if (fp) {
-        fp.textContent = fingerprint
-          ? `v${fingerprint.key_version}: ${formatFingerprint(fingerprint.key_fingerprint)}`
+        fp.textContent = activeKey
+          ? `v${activeKey.key_version}: ${formatFingerprint(activeKey.key_fingerprint)}`
           : formatFingerprint(null);
       }
-      if (verificationStatus) {
-        const verified = Boolean(fingerprint);
-        verificationStatus.className = `font-semibold ${verified ? 'text-emerald-500' : 'text-amber-500'} flex items-center space-x-1`;
-        verificationStatus.innerHTML = verified
-          ? '<i data-lucide="shield-check" class="w-3.5 h-3.5 mr-0.5 inline-block text-emerald-500"></i><span>' + (currentLanguage === 'zh' ? '已加载真实指纹' : 'Real fingerprint loaded') + '</span>'
-          : '<i data-lucide="shield-alert" class="w-3.5 h-3.5 mr-0.5 inline-block text-amber-500"></i><span>' + (currentLanguage === 'zh' ? '缺少公钥' : 'No public key') + '</span>';
-      }
+      setVerificationStatus(verificationStatus, activeKey ? activeKey.trust_status : 'missing', keyChanged);
     } else if (fp) {
       fp.textContent = currentLanguage === 'zh'
         ? '群聊使用每位成员的当前公钥加密。'
@@ -1090,6 +1472,19 @@ async function sendMessage() {
   const time = formatClockTime();
   const clientMsgId = `client-${Date.now()}-${Math.random().toString(16).slice(2)}`;
 
+  // Capture reply info before clearing
+  const replyInfo = replyToMessage;
+  if (replyToMessage) {
+    // Clear reply state
+    replyToMessage = null;
+    if (typeof MessageActions !== 'undefined' && MessageActions.cancelReply) {
+      MessageActions.cancelReply();
+    } else {
+      var banner = document.getElementById('reply-quote-banner');
+      if (banner) banner.style.display = 'none';
+    }
+  }
+
   // Optimistic render
   const tempMsg = {
     id: clientMsgId,
@@ -1097,6 +1492,7 @@ async function sendMessage() {
     time: time,
     isSelf: true,
     status: "sending",
+    reply_to: replyInfo ? replyInfo.id : null,
   };
   messages.push(tempMsg);
   renderMessages();
@@ -1128,7 +1524,8 @@ async function sendMessage() {
               message_type: "text",
               algorithm: result.algorithm,
               client_message_id: clientMsgId,
-              recipients: result.recipients
+              recipients: result.recipients,
+              reply_to: tempMsg.reply_to || undefined
             }
           })) {
             throw new Error("WebSocket is not connected.");
@@ -1150,6 +1547,7 @@ async function sendMessage() {
             receiver_key_version: result.receiver_key_version,
             client_message_id: clientMsgId,
             message_type: "text",
+            reply_to: tempMsg.reply_to || undefined,
           })
         });
         handleMessageAccepted({ data: accepted });
@@ -1287,23 +1685,135 @@ async function showFingerprintModal() {
   if (!activeChatId) return;
   const conv = conversationsById[activeChatId];
   if (!conv || !conv.is_secure) return;
-  document.getElementById("fp-modal-name").textContent = conv.name || "Unknown";
   const keyEl = document.getElementById("fp-modal-key");
+  const statusEl = document.getElementById("fp-modal-status");
+  const actionBtn = document.getElementById("fp-modal-trust-btn");
+  const untrustBtn = document.getElementById("fp-modal-untrust-btn");
+  const warningEl = document.getElementById("fp-modal-warning");
   if (keyEl) {
     keyEl.textContent = currentLanguage === 'zh' ? '正在加载真实指纹...' : 'Loading real fingerprint...';
+  }
+  if (statusEl) {
+    statusEl.className = 'security-status-chip security-status-loading';
+    statusEl.textContent = currentLanguage === 'zh' ? '正在加载信任状态' : 'Loading trust status';
+  }
+  if (warningEl) warningEl.classList.add("hidden");
+  if (actionBtn) {
+    actionBtn.classList.add("hidden");
+    actionBtn.disabled = true;
+  }
+  if (untrustBtn) {
+    untrustBtn.classList.add("hidden");
+    untrustBtn.disabled = true;
   }
   const modal = document.getElementById("fingerprint-modal");
   if (modal) { modal.classList.remove("hidden"); modal.classList.add("flex"); }
   if (conv.type === "single" && conv.peer_id) {
-    const fingerprint = await fetchPeerFingerprint(conv.peer_id);
-    if (activeChatId !== conv.id || !keyEl) return;
-    keyEl.textContent = fingerprint
-      ? `v${fingerprint.key_version}: ${formatFingerprint(fingerprint.key_fingerprint)}`
+    const contactStatus = await fetchContactKeyStatus(conv.peer_id);
+    if (String(activeChatId) !== String(conv.id) || !keyEl) return;
+    const activeKey = getActiveKeyStatus(contactStatus);
+    const keyChanged = contactKeyHasChanged(contactStatus);
+    keyEl.textContent = activeKey
+      ? `v${activeKey.key_version}: ${formatFingerprint(activeKey.key_fingerprint)}`
       : formatFingerprint(null);
+    renderFingerprintModalState(conv, activeKey, keyChanged);
   } else if (keyEl) {
     keyEl.textContent = currentLanguage === 'zh'
       ? '群聊没有单一联系人指纹，请分别验证成员公钥。'
       : 'Group chats do not have one peer fingerprint; verify member keys individually.';
+    if (statusEl) {
+      statusEl.className = 'security-status-chip security-status-unverified';
+      statusEl.textContent = currentLanguage === 'zh' ? '请在成员列表逐个验证' : 'Verify members individually';
+    }
+  }
+}
+
+function renderFingerprintModalState(conv, activeKey, keyChanged) {
+  const statusEl = document.getElementById("fp-modal-status");
+  const actionBtn = document.getElementById("fp-modal-trust-btn");
+  const untrustBtn = document.getElementById("fp-modal-untrust-btn");
+  const warningEl = document.getElementById("fp-modal-warning");
+  const explainEl = document.getElementById("fp-modal-explain-container");
+
+  if (warningEl) {
+    warningEl.classList.toggle("hidden", !keyChanged);
+    warningEl.textContent = currentLanguage === 'zh'
+      ? '高风险警告：这个联系人当前公钥与此前已验证的指纹不同。请通过其他渠道确认后再重新验证。'
+      : 'High risk: this contact active key differs from a previously verified fingerprint. Confirm out-of-band before re-verifying.';
+  }
+
+  if (explainEl) {
+    explainEl.innerHTML = currentLanguage === 'zh'
+      ? '请与 <strong id="fp-modal-name">' + escapeHtml(conv.name || 'this contact') + '</strong> 通过其他渠道核对下方真实指纹：'
+      : 'Verify with <strong id="fp-modal-name">' + escapeHtml(conv.name || 'this contact') + '</strong> that the real fingerprint below matches:';
+  }
+
+  if (!activeKey) {
+    if (statusEl) {
+      statusEl.className = 'security-status-chip security-status-missing';
+      statusEl.textContent = currentLanguage === 'zh' ? '缺少公钥' : 'No public key';
+    }
+    if (actionBtn) actionBtn.classList.add("hidden");
+    if (untrustBtn) untrustBtn.classList.add("hidden");
+    return;
+  }
+
+  const trusted = activeKey.trust_status === 'trusted' || activeKey.trust_status === 'verified';
+  if (statusEl) {
+    statusEl.className = 'security-status-chip ' + (keyChanged ? 'security-status-danger' : trusted ? 'security-status-verified' : 'security-status-unverified');
+    statusEl.textContent = keyChanged
+      ? (currentLanguage === 'zh' ? '密钥已变更' : 'Key changed')
+      : trusted
+        ? (currentLanguage === 'zh' ? '已验证' : 'Verified')
+        : (currentLanguage === 'zh' ? '未验证' : 'Unverified');
+  }
+
+  if (actionBtn) {
+    actionBtn.classList.remove("hidden");
+    actionBtn.disabled = false;
+    actionBtn.textContent = trusted && !keyChanged
+      ? (currentLanguage === 'zh' ? '重新验证当前指纹' : 'Re-verify Current Fingerprint')
+      : (currentLanguage === 'zh' ? '标记为已验证' : 'Mark as Verified');
+  }
+  if (untrustBtn) {
+    untrustBtn.classList.toggle("hidden", !trusted);
+    untrustBtn.disabled = !trusted;
+  }
+}
+
+async function trustActiveFingerprintFromModal() {
+  const conv = conversationsById[activeChatId];
+  if (!conv || conv.type !== "single" || !conv.peer_id) return;
+  const actionBtn = document.getElementById("fp-modal-trust-btn");
+  if (actionBtn) actionBtn.disabled = true;
+  try {
+    const result = await setContactKeyTrust(conv.peer_id, 'verified');
+    const activeKey = getActiveKeyStatus(result.refreshed);
+    renderFingerprintModalState(conv, activeKey, false);
+    updateDetailsPanel(conv);
+    window.showToast(currentLanguage === 'zh' ? '联系人密钥已标记为已验证' : 'Contact key marked as verified.');
+  } catch (err) {
+    window.showToast(err.message || (currentLanguage === 'zh' ? '验证失败' : 'Verification failed'));
+  } finally {
+    if (actionBtn) actionBtn.disabled = false;
+  }
+}
+
+async function untrustActiveFingerprintFromModal() {
+  const conv = conversationsById[activeChatId];
+  if (!conv || conv.type !== "single" || !conv.peer_id) return;
+  const untrustBtn = document.getElementById("fp-modal-untrust-btn");
+  if (untrustBtn) untrustBtn.disabled = true;
+  try {
+    await clearContactKeyTrust(conv.peer_id);
+    const refreshed = await fetchContactKeyStatus(conv.peer_id, { force: true });
+    renderFingerprintModalState(conv, getActiveKeyStatus(refreshed), contactKeyHasChanged(refreshed));
+    updateDetailsPanel(conv);
+    window.showToast(currentLanguage === 'zh' ? '已撤销当前密钥信任' : 'Trust removed for the current key.');
+  } catch (err) {
+    window.showToast(err.message || (currentLanguage === 'zh' ? '撤销失败' : 'Could not remove trust'));
+  } finally {
+    if (untrustBtn) untrustBtn.disabled = false;
   }
 }
 
@@ -1387,6 +1897,13 @@ function createMessageBubbleElementNew(msg, groupMeta, conv) {
     div.onclick = function(e) {
       if (isSelectingMessages) { e.stopPropagation(); toggleMessageSelection(msg.id); }
     };
+    div.oncontextmenu = function(e) {
+      e.preventDefault();
+      e.stopPropagation();
+      if (typeof MessageActions !== 'undefined' && MessageActions.showMenu) {
+        MessageActions.showMenu(e, msg, conv || conversationsById[activeChatId]);
+      }
+    };
   }
 
   var checkboxHtml = '<div class="message-select-checkbox select-none ' + (isSelectingMessages ? "" : "hidden") + '" id="msg-select-check-' + msg.id + '"><i data-lucide="' + (selectedMessageIds.includes(msg.id) ? "check-circle-2" : "circle") + '" class="w-5 h-5 text-textSecondary"></i></div>';
@@ -1400,15 +1917,34 @@ function createMessageBubbleElementNew(msg, groupMeta, conv) {
     div.className += " message-row-self";
     if (isSelectingMessages) div.className += " message-row-selecting";
     var statusIcon = "check";
-    if (msg.status === "delivered" || msg.status === "sent") statusIcon = "check-check";
-    if (msg.status === "read") statusIcon = "check-check";
+    var statusIconClass = "msg-status-icon";
+    var statusTooltip = "";
+    if (msg.status === "sending") {
+      statusIcon = "clock";
+      statusIconClass += " msg-status-sending";
+      statusTooltip = currentLanguage === 'zh' ? '发送中...' : 'Sending...';
+    } else if (msg.status === "sent") {
+      statusIcon = "check";
+      statusTooltip = currentLanguage === 'zh' ? '已发送' : 'Sent';
+    } else if (msg.status === "delivered") {
+      statusIcon = "check-check";
+      statusTooltip = currentLanguage === 'zh' ? '已送达' : 'Delivered';
+    } else if (msg.status === "read") {
+      statusIcon = "check-check";
+      statusIconClass += " msg-status-read";
+      statusTooltip = currentLanguage === 'zh' ? '已读' : 'Read';
+    } else if (msg.status === "failed" || msg.client_status === "failed") {
+      statusIcon = "alert-circle";
+      statusIconClass += " msg-status-failed";
+      statusTooltip = currentLanguage === 'zh' ? '发送失败' : 'Failed to send';
+    }
     var statusClass = msg.status === "read" ? "text-brand-light dark:text-brand-dark" : "";
     div.innerHTML = checkboxHtml
       + '<div class="message-bubble-custom bubble-self" data-message-id="' + msg.id + '">'
       + '<p class="message-text-content">' + messageText + '</p>'
       + '<div class="message-meta-line">'
       + '<span>' + messageTime + '</span>'
-      + '<i data-lucide="' + statusIcon + '" class="w-3.5 h-3.5 ' + statusClass + '"></i>'
+      + '<i data-lucide="' + statusIcon + '" class="w-3.5 h-3.5 ' + statusIconClass + ' ' + statusClass + '" title="' + statusTooltip + '"></i>'
       + '</div></div>';
   } else {
     div.className += " message-row-peer";
@@ -1541,6 +2077,14 @@ function setupEventListeners() {
         mainBtn.classList.remove("bg-bgSearch", "text-textMain");
       }
     }
+    // 3. Contacts FAB menu (P2 T09)
+    const fabMenu = document.getElementById("contacts-fab-menu");
+    const fabBtn = document.getElementById("contacts-fab-btn");
+    if (fabMenu && !fabMenu.classList.contains("hidden")) {
+      if (fabBtn && !fabBtn.contains(e.target) && !fabMenu.contains(e.target)) {
+        closeContactsFab();
+      }
+    }
   });
 
   // Handle ESC key press to close dropdowns and modals
@@ -1566,6 +2110,7 @@ function setupEventListeners() {
       closeAutoDeletePicker();
       closeBlockedUsersList();
       closePrivacyConfirmModal();
+      closeContactsFab();
     }
   });
 
@@ -1697,6 +2242,22 @@ function setupEventListeners() {
   });
 
   window.addEventListener("hashchange", handleMobileNavigation);
+
+  // P2 T10: Search sidebar input with debounce
+  var searchSidebarInput = document.getElementById('search-sidebar-input');
+  if (searchSidebarInput) {
+    searchSidebarInput.addEventListener('input', function() {
+      clearTimeout(searchDebounceTimer);
+      var clearBtn = document.getElementById('search-sidebar-clear');
+      if (clearBtn) clearBtn.classList.toggle('hidden', !this.value.trim());
+      searchDebounceTimer = setTimeout(performSearch, 300);
+    });
+    searchSidebarInput.addEventListener('keydown', function(e) {
+      if (e.key === 'Escape') {
+        clearSearchSidebar();
+      }
+    });
+  }
 }
 
 // 14. Additional Interface Utilities
@@ -1788,6 +2349,606 @@ function showSettingsPanel() {
 
 function hideSettingsPanel() {
   navigateSidebar('chat');
+}
+
+// ============================================================================
+// P2 T09: Contacts FAB (Floating Action Button) & header search
+// ============================================================================
+
+function toggleContactsFab(event) {
+  event.stopPropagation();
+  const btn = document.getElementById('contacts-fab-btn');
+  const menu = document.getElementById('contacts-fab-menu');
+  if (!btn || !menu) return;
+  const isOpen = !menu.classList.contains('hidden');
+  if (isOpen) {
+    menu.classList.add('hidden');
+    btn.classList.remove('expanded');
+  } else {
+    menu.classList.remove('hidden');
+    btn.classList.add('expanded');
+    if (window.lucide) lucide.createIcons();
+  }
+}
+
+function fabNewPrivateChat(event) {
+  event.stopPropagation();
+  closeContactsFab();
+  // Open the existing contacts modal for adding a contact to start a private chat
+  const contactsModal = document.getElementById('contacts-modal');
+  if (contactsModal) {
+    contactsModal.classList.remove('hidden');
+    contactsModal.classList.add('flex');
+  }
+}
+
+function fabNewGroup(event) {
+  event.stopPropagation();
+  closeContactsFab();
+  // Open the existing group creation modal
+  const groupModal = document.getElementById('group-modal');
+  if (groupModal) {
+    populateGroupMembersList();
+    groupModal.classList.remove('hidden');
+    groupModal.classList.add('flex');
+  }
+}
+
+function fabNewChannel(event) {
+  event.stopPropagation();
+  closeContactsFab();
+  window.showToast(currentLanguage === 'zh' ? '频道功能暂未开放' : 'Channels are not yet available');
+}
+
+function closeContactsFab() {
+  const btn = document.getElementById('contacts-fab-btn');
+  const menu = document.getElementById('contacts-fab-menu');
+  if (menu) menu.classList.add('hidden');
+  if (btn) btn.classList.remove('expanded');
+}
+
+function filterContactsInSidebar(query) {
+  const trimmed = (query || '').toLowerCase().trim();
+  const sections = document.querySelectorAll('#sidebar-contacts-content > .divide-y > div');
+  const contactItems = document.querySelectorAll('#sidebar-contacts-content [data-contact-search]');
+
+  if (!trimmed) {
+    // Show all sections, all items
+    if (sections.length) sections.forEach(function(s) { s.style.display = ''; });
+    contactItems.forEach(function(el) { el.style.display = ''; });
+    return;
+  }
+
+  contactItems.forEach(function(el) {
+    const searchText = (el.getAttribute('data-contact-search') || '').toLowerCase();
+    el.style.display = searchText.includes(trimmed) ? '' : 'none';
+  });
+
+  // Hide section headers when searching (simplifies view)
+  if (sections.length) {
+    sections.forEach(function(s) {
+      // Keep visible if it contains visible contact items
+      const visibleItems = s.querySelectorAll('[data-contact-search]');
+      let hasVisible = false;
+      visibleItems.forEach(function(item) {
+        if (item.style.display !== 'none') hasVisible = true;
+      });
+      s.style.display = hasVisible ? '' : 'none';
+    });
+  }
+}
+
+// ============================================================================
+// P2 T10: Search Sidebar
+// ============================================================================
+
+function switchSearchTab(tab) {
+  currentSearchTab = tab;
+  // Update active tab styling
+  document.querySelectorAll('.search-type-tab').forEach(function(btn) {
+    btn.classList.toggle('active', btn.getAttribute('data-tab') === tab);
+  });
+  // Show/hide scope bar (only for chats)
+  const scopeBar = document.getElementById('search-scope-bar');
+  if (scopeBar) {
+    scopeBar.style.display = (tab === 'chats') ? '' : 'none';
+  }
+  // Show placeholder for non-chats tabs
+  if (tab !== 'chats') {
+    showSearchPlaceholder(tab);
+  } else {
+    // Re-run search if input has text
+    const input = document.getElementById('search-sidebar-input');
+    if (input && input.value.trim()) {
+      performSearch();
+    } else {
+      showSearchEmpty();
+    }
+  }
+}
+
+function onSearchScopeChange() {
+  const input = document.getElementById('search-sidebar-input');
+  if (input && input.value.trim()) {
+    performSearch();
+  }
+}
+
+function clearSearchSidebar() {
+  const input = document.getElementById('search-sidebar-input');
+  const clearBtn = document.getElementById('search-sidebar-clear');
+  if (input) input.value = '';
+  if (clearBtn) clearBtn.classList.add('hidden');
+  showSearchEmpty();
+}
+
+function performSearch() {
+  var input = document.getElementById('search-sidebar-input');
+  var clearBtn = document.getElementById('search-sidebar-clear');
+  var query = input ? input.value.trim() : '';
+
+  // Toggle clear button
+  if (clearBtn) {
+    clearBtn.classList.toggle('hidden', !query);
+  }
+
+  if (!query) {
+    showSearchEmpty();
+    return;
+  }
+
+  if (currentSearchTab !== 'chats') {
+    showSearchPlaceholder(currentSearchTab);
+    return;
+  }
+
+  // Show loading
+  var emptyState = document.getElementById('search-empty-state');
+  var resultsContent = document.getElementById('search-results-content');
+  var loading = document.getElementById('search-loading');
+  if (emptyState) emptyState.classList.add('hidden');
+  if (resultsContent) resultsContent.classList.add('hidden');
+  if (loading) loading.classList.remove('hidden');
+
+  var scope = document.getElementById('search-scope-select');
+  var scopeValue = scope ? scope.value : 'all';
+
+  var url = '/api/search/?q=' + encodeURIComponent(query) + '&scope=' + encodeURIComponent(scopeValue);
+
+  // Race-condition guard: only render if the input hasn't changed since request
+  var sentQuery = query;
+  fetch(url)
+    .then(function(r) { return r.json(); })
+    .then(function(data) {
+      if (loading) loading.classList.add('hidden');
+      var currentInput = document.getElementById('search-sidebar-input');
+      var currentQuery = currentInput ? currentInput.value.trim() : '';
+      if (currentQuery !== sentQuery) return; // stale response, discard
+      renderSearchResults(data, currentQuery);
+    })
+    .catch(function(err) {
+      if (loading) loading.classList.add('hidden');
+      console.error('Search failed:', err);
+      showSearchEmpty();
+      window.showToast(currentLanguage === 'zh' ? '搜索失败，请重试' : 'Search failed. Please retry.');
+    });
+}
+
+function renderSearchResults(data, query) {
+  var emptyState = document.getElementById('search-empty-state');
+  var resultsContent = document.getElementById('search-results-content');
+  if (!resultsContent) return;
+
+  resultsContent.innerHTML = '';
+  var hasContent = false;
+
+  // Group: Contacts
+  var contacts = (data.results && data.results.contacts) ? data.results.contacts : [];
+  if (contacts.length > 0) {
+    hasContent = true;
+    resultsContent.appendChild(createResultGroupLabel('Contacts'));
+    contacts.forEach(function(c) {
+      resultsContent.appendChild(createSearchResultItem({
+        initials: (c.username || '?')[0].toUpperCase(),
+        name: c.nickname || c.username || 'Unknown',
+        subtitle: c.is_contact ? (currentLanguage === 'zh' ? '已是联系人' : 'Already a contact') : ('@' + (c.username || '')),
+        color: '#5c6bc0',
+        onclick: function() {
+          if (c.is_contact) {
+            // Navigate to chat with this contact
+            apiFetch('/api/conversations/create/', {
+              method: 'POST',
+              body: JSON.stringify({ peer_id: c.id })
+            }).then(function(resp) {
+              navigateSidebar('chat');
+              fetchConversations().then(function() {
+                if (resp.conversation_id) selectChat(resp.conversation_id.toString());
+              });
+            }).catch(function(err) {
+              window.showToast(err.message);
+            });
+          } else {
+            // Open add-contact flow — fill the Add Contact form in contacts view
+            clearSearchSidebar();
+            navigateSidebar('contacts');
+            setTimeout(function() {
+              var addInput = document.getElementById('contact-search-input');
+              if (addInput) { addInput.value = c.username; addInput.focus(); }
+            }, 150);
+          }
+        }
+      }));
+    });
+  }
+
+  // Group: Groups
+  var groups = (data.results && data.results.groups) ? data.results.groups : [];
+  if (groups.length > 0) {
+    hasContent = true;
+    resultsContent.appendChild(createResultGroupLabel('Groups'));
+    groups.forEach(function(g) {
+      resultsContent.appendChild(createSearchResultItem({
+        initials: (g.name || 'G')[0].toUpperCase(),
+        name: g.name || 'Unnamed Group',
+        subtitle: (g.is_member ? '' : (currentLanguage === 'zh' ? '未加入 · ' : 'Not joined · ')) + (g.member_count || 0) + ' members',
+        color: '#6f42c1',
+        onclick: function() {
+          if (g.is_member) {
+            navigateSidebar('chat');
+            // Match group by Conversation ID (g.id === Conversation.id)
+            fetchConversations().then(function() {
+              var conv = conversationsById[g.id];
+              if (!conv) {
+                // Fallback: id-based scan
+                conv = conversations.find(function(c) { return c.type === 'group' && c.id === g.id; });
+              }
+              if (conv) selectChat(conv.id.toString());
+            });
+          } else {
+            window.showToast(currentLanguage === 'zh' ? '你尚未加入该群组' : 'You are not a member of this group');
+          }
+        }
+      }));
+    });
+  }
+
+  // Group: Conversations
+  var conversations_ = (data.results && data.results.conversations) ? data.results.conversations : [];
+  if (conversations_.length > 0) {
+    hasContent = true;
+    resultsContent.appendChild(createResultGroupLabel('Conversations'));
+    conversations_.forEach(function(conv) {
+      resultsContent.appendChild(createSearchResultItem({
+        initials: (conv.peer_display_name || conv.peer_username || '?')[0].toUpperCase(),
+        name: conv.peer_display_name || conv.peer_username || 'Unknown',
+        subtitle: '@' + (conv.peer_username || ''),
+        color: '#3390ec',
+        onclick: function() {
+          navigateSidebar('chat');
+          if (conv.conversation_id) {
+            selectChat(conv.conversation_id.toString());
+          }
+        }
+      }));
+    });
+  }
+
+  if (!hasContent) {
+    if (emptyState) emptyState.classList.remove('hidden');
+    resultsContent.classList.add('hidden');
+    var emptyP = emptyState ? emptyState.querySelector('p') : null;
+    if (emptyP) emptyP.textContent = currentLanguage === 'zh'
+      ? '未找到与 "' + query + '" 相关的结果'
+      : 'No results found for "' + query + '"';
+  } else {
+    if (emptyState) emptyState.classList.add('hidden');
+    resultsContent.classList.remove('hidden');
+  }
+}
+
+function createResultGroupLabel(text) {
+  var div = document.createElement('div');
+  div.className = 'search-result-group-label';
+  div.textContent = text;
+  return div;
+}
+
+function createSearchResultItem(opts) {
+  var btn = document.createElement('button');
+  btn.className = 'search-result-item';
+  btn.onclick = opts.onclick;
+  var safeColor = /^#[0-9a-fA-F]{6}$/.test(opts.color || '') ? opts.color : '#5c6bc0';
+  btn.innerHTML = '<div class="result-avatar" style="background-color:' + safeColor + '">'
+    + escapeHtml(opts.initials || '?')
+    + '</div>'
+    + '<div class="result-info">'
+    + '<div class="result-name">' + escapeHtml(opts.name || '') + '</div>'
+    + '<div class="result-subtitle">' + escapeHtml(opts.subtitle || '') + '</div>'
+    + '</div>';
+  return btn;
+}
+
+function showSearchEmpty() {
+  var emptyState = document.getElementById('search-empty-state');
+  var resultsContent = document.getElementById('search-results-content');
+  var loading = document.getElementById('search-loading');
+  if (emptyState) {
+    emptyState.classList.remove('hidden');
+    var p = emptyState.querySelector('p');
+    if (p) p.textContent = currentLanguage === 'zh'
+      ? '搜索聊天、联系人和消息'
+      : 'Search for chats, contacts, and messages';
+  }
+  if (resultsContent) resultsContent.classList.add('hidden');
+  if (loading) loading.classList.add('hidden');
+}
+
+function showSearchPlaceholder(tab) {
+  var emptyState = document.getElementById('search-empty-state');
+  var resultsContent = document.getElementById('search-results-content');
+  var loading = document.getElementById('search-loading');
+  if (resultsContent) resultsContent.classList.add('hidden');
+  if (loading) loading.classList.add('hidden');
+  if (emptyState) {
+    emptyState.classList.remove('hidden');
+    var labels = {
+      channels: currentLanguage === 'zh' ? '频道搜索暂未开放' : 'Channel search is not yet available',
+      apps: currentLanguage === 'zh' ? 'Apps 搜索暂未开放' : 'Apps search is not yet available',
+      posts: currentLanguage === 'zh' ? 'Posts 搜索暂未开放' : 'Posts search is not yet available'
+    };
+    var p = emptyState.querySelector('p');
+    if (p) p.textContent = labels[tab] || labels.channels;
+  }
+}
+
+function _kmgr() {
+  return window.iChatKeyManager;
+}
+
+function setTextById(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = value;
+}
+
+function setStatusGlyph(el, ok, missingLabel = '-') {
+  if (!el) return;
+  el.textContent = ok ? 'OK' : missingLabel;
+  el.classList.remove('text-green-500', 'text-red-400', 'text-gray-400', 'text-amber-500');
+  el.classList.add(ok ? 'text-green-500' : missingLabel === '!' ? 'text-amber-500' : 'text-red-400');
+}
+
+function toggleKeyManagement() {
+  const panel = document.getElementById('key-mgmt-panel');
+  const chevron = document.getElementById('key-mgmt-chevron');
+  if (!panel) return;
+  const isHidden = panel.classList.contains('hidden');
+  panel.classList.toggle('hidden', !isHidden);
+  if (chevron) chevron.style.transform = isHidden ? 'rotate(180deg)' : 'rotate(0deg)';
+  if (isHidden) refreshKeyUI();
+}
+
+async function refreshKeyUI() {
+  const kmgr = _kmgr();
+  const record = kmgr ? kmgr.loadCurrentRecord() : null;
+  const fpEl = document.getElementById('key-fingerprint-display');
+  const statusDot = document.querySelector('#key-status-badge span.w-2');
+  const statusText = document.getElementById('key-status-text');
+  const subtitle = document.getElementById('key-mgmt-subtitle');
+  const genBtn = document.getElementById('btn-key-generate');
+  const uploadBtn = document.getElementById('btn-key-upload');
+
+  if (fpEl) fpEl.textContent = record && record.key_fingerprint ? formatFingerprint(record.key_fingerprint) : '-';
+  if (record && record.key_fingerprint) {
+    if (subtitle) subtitle.textContent = 'ECDH P-256 keys stored locally';
+    if (statusDot) {
+      statusDot.classList.remove('bg-gray-400', 'bg-red-400');
+      statusDot.classList.add('bg-green-500');
+    }
+    if (statusText) statusText.textContent = record.key_version ? `Keys synced (v${record.key_version})` : 'Keys ready';
+    if (genBtn) {
+      genBtn.disabled = false;
+      genBtn.textContent = 'Re-initialize Keys';
+    }
+    if (uploadBtn) uploadBtn.disabled = false;
+  } else {
+    if (subtitle) subtitle.textContent = 'No key pair found. Initialize one to enable E2EE.';
+    if (statusDot) {
+      statusDot.classList.remove('bg-green-500', 'bg-red-400');
+      statusDot.classList.add('bg-gray-400');
+    }
+    if (statusText) statusText.textContent = 'No local keys';
+    if (genBtn) {
+      genBtn.disabled = false;
+      genBtn.textContent = 'Initialize Keys';
+    }
+    if (uploadBtn) uploadBtn.disabled = true;
+  }
+
+  try {
+    const data = await apiFetch('/api/keys/fingerprints/');
+    const activeKey = (data.keys || []).find(key => key.is_active) || (data.keys || [])[0];
+    if (activeKey) {
+      setTextById('key-version-display', `v${activeKey.key_version}`);
+      if (fpEl) fpEl.textContent = formatFingerprint(activeKey.key_fingerprint);
+    } else {
+      setTextById('key-version-display', '-');
+    }
+    setTextById('key-trusted-by-display', String(data.trusted_by_count || 0));
+  } catch (err) {
+    setTextById('key-version-display', '-');
+    setTextById('key-trusted-by-display', '-');
+  }
+}
+
+function _showKeyMsg(text, isError = false) {
+  const el = document.getElementById('key-mgmt-message');
+  if (!el) return;
+  el.textContent = text;
+  el.className = 'text-xs p-2.5 rounded-custom-md border';
+  el.classList.add(
+    isError ? 'bg-red-50' : 'bg-green-50',
+    isError ? 'border-red-200' : 'border-green-200',
+    isError ? 'text-red-700' : 'text-green-700',
+    isError ? 'dark:bg-red-950/20' : 'dark:bg-green-950/20',
+    isError ? 'dark:border-red-900/50' : 'dark:border-green-900/50',
+    isError ? 'dark:text-red-400' : 'dark:text-green-400'
+  );
+  setTimeout(() => el.classList.add('hidden'), 5000);
+}
+
+async function keyMgrGenerate() {
+  const btn = document.getElementById('btn-key-generate');
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Initializing...';
+  }
+  try {
+    const kmgr = _kmgr();
+    if (!kmgr) throw new Error('Key manager is not available.');
+    const record = await kmgr.initialize();
+    _showKeyMsg(`ECDH P-256 keys initialized and synced. Version: ${record.key_version}`);
+    await refreshKeyUI();
+    await refreshSecurityStatus();
+  } catch (err) {
+    _showKeyMsg(`Initialization failed: ${err.message}`, true);
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Initialize Keys';
+    }
+  }
+}
+
+async function keyMgrUpload() {
+  const btn = document.getElementById('btn-key-upload');
+  if (btn) {
+    btn.disabled = true;
+    btn.textContent = 'Uploading...';
+  }
+  try {
+    const kmgr = _kmgr();
+    if (!kmgr) throw new Error('Key manager is not available.');
+    await kmgr.uploadCurrentRecord();
+    _showKeyMsg('Public key re-synced to server.');
+    await refreshKeyUI();
+  } catch (err) {
+    _showKeyMsg(`Upload failed: ${err.message}`, true);
+  } finally {
+    if (btn) {
+      btn.disabled = false;
+      btn.textContent = 'Upload to Server';
+    }
+  }
+}
+
+function keyMgrExport() {
+  try {
+    const kmgr = _kmgr();
+    if (!kmgr || !kmgr.loadCurrentRecord()) {
+      _showKeyMsg('No keys to export. Initialize them first.', true);
+      return;
+    }
+    kmgr.exportBackup();
+    _showKeyMsg('Backup downloaded. Keep it safe.');
+  } catch (err) {
+    _showKeyMsg(`Export failed: ${err.message}`, true);
+  }
+}
+
+async function keyMgrImport(event) {
+  const file = event.target.files[0];
+  if (!file) return;
+  try {
+    const kmgr = _kmgr();
+    if (!kmgr) throw new Error('Key manager is not available.');
+    const record = await kmgr.importBackup(file);
+    _showKeyMsg(`Keys restored. Fingerprint: ${record.key_fingerprint.slice(0, 16)}...`);
+    await refreshKeyUI();
+    await refreshSecurityStatus();
+  } catch (err) {
+    _showKeyMsg(`Import failed: ${err.message}`, true);
+  } finally {
+    event.target.value = '';
+  }
+}
+
+function toggleSecurityStatus() {
+  const panel = document.getElementById('security-status-panel');
+  const chevron = document.getElementById('security-status-chevron');
+  if (!panel) return;
+  const isHidden = panel.classList.contains('hidden');
+  panel.classList.toggle('hidden', !isHidden);
+  if (chevron) chevron.style.transform = isHidden ? 'rotate(180deg)' : 'rotate(0deg)';
+  if (isHidden) refreshSecurityStatus();
+}
+
+async function fetchKeyTrustList({ force = false } = {}) {
+  if (!force && keyTrustListCache) return keyTrustListCache;
+  const data = await apiFetch('/api/keys/trust/');
+  keyTrustListCache = data.trusts || [];
+  return keyTrustListCache;
+}
+
+function renderTrustList(trusts) {
+  const list = document.getElementById('security-trust-list');
+  if (!list) return;
+  list.innerHTML = '';
+  if (!trusts.length) {
+    list.innerHTML = '<div class="text-[10px] text-textSecondary text-center py-2">No verified contact keys yet.</div>';
+    return;
+  }
+  trusts.forEach(trust => {
+    const row = document.createElement('div');
+    const changed = Boolean(trust.key_changed);
+    row.className = 'security-trust-row';
+    row.innerHTML =
+      '<div class="min-w-0">' +
+        '<div class="text-xs font-semibold text-textMain truncate">' + escapeHtml(trust.contact_username || 'Unknown') + '</div>' +
+        '<div class="text-[10px] text-textSecondary font-mono truncate">v' + escapeHtml(trust.key_version) + ' ' + escapeHtml(formatFingerprint(trust.key_fingerprint)) + '</div>' +
+      '</div>' +
+      '<span class="' + (changed ? 'security-status-chip security-status-danger' : 'security-status-chip security-status-verified') + '">' +
+        (changed ? (currentLanguage === 'zh' ? '已变更' : 'Changed') : escapeHtml(trust.trust_status || 'trusted')) +
+      '</span>';
+    list.appendChild(row);
+  });
+}
+
+async function refreshSecurityStatus() {
+  const keysEl = document.getElementById('sec-keys-status');
+  const serverEl = document.getElementById('sec-server-status');
+  const trustEl = document.getElementById('sec-trust-status');
+  const kmgr = _kmgr();
+  const record = kmgr ? kmgr.loadCurrentRecord() : null;
+  setStatusGlyph(keysEl, Boolean(record && record.key_fingerprint));
+
+  try {
+    const data = await apiFetch('/api/keys/fingerprints/');
+    const activeKey = (data.keys || []).find(key => key.is_active);
+    setStatusGlyph(serverEl, Boolean(activeKey));
+    if (activeKey) {
+      setTextById('key-version-display', `v${activeKey.key_version}`);
+      setTextById('key-trusted-by-display', String(data.trusted_by_count || 0));
+    }
+  } catch (err) {
+    setStatusGlyph(serverEl, false);
+  }
+
+  try {
+    const trusts = await fetchKeyTrustList({ force: true });
+    const changedCount = trusts.filter(trust => trust.key_changed).length;
+    if (trustEl) {
+      trustEl.textContent = changedCount > 0 ? '!' : String(trusts.length);
+      trustEl.classList.remove('text-green-500', 'text-red-400', 'text-gray-400', 'text-amber-500');
+      trustEl.classList.add(changedCount > 0 ? 'text-amber-500' : trusts.length > 0 ? 'text-green-500' : 'text-gray-400');
+    }
+    renderTrustList(trusts);
+  } catch (err) {
+    if (trustEl) {
+      trustEl.textContent = '-';
+      trustEl.classList.remove('text-green-500', 'text-red-400', 'text-amber-500');
+      trustEl.classList.add('text-gray-400');
+    }
+  }
 }
 
 function setupSidebarResizer() {
@@ -2037,7 +3198,74 @@ const translations = {
     menu_add_account: "Add Account",
     menu_more: "More",
     menu_about: "About iChat Pro",
-    menu_updates: "Check Updates"
+    menu_updates: "Check Updates",
+    // T12: Conversation actions
+    convPin: "Pin",
+    convUnpin: "Unpin",
+    convPinned: "Pinned",
+    convUnpinned: "Unpinned",
+    convMute: "Mute",
+    convUnmute: "Unmute",
+    convMuted: "Muted",
+    convUnmuted: "Unmuted",
+    convMute1h: "Mute for 1 hour",
+    convMute8h: "Mute for 8 hours",
+    convMute24h: "Mute for 24 hours",
+    convMuteForever: "Mute forever",
+    convArchive: "Archive",
+    convUnarchive: "Unarchive",
+    convArchived: "Archived",
+    convUnarchived: "Unarchived",
+    convClear: "Clear History",
+    convDelete: "Delete Chat",
+    convMarkRead: "Mark as Read",
+    convMarkUnread: "Mark as Unread",
+    convMarkedRead: "Marked as read",
+    convMarkedUnread: "Marked as unread",
+    convCleared: "History cleared",
+    convDeleted: "Conversation deleted",
+    convClearConfirm: "Clear all messages in this chat?",
+    convDeleteConfirm: "Delete this conversation?",
+    convActionFailed: "Action failed",
+    // T13: Message actions
+    msgCopy: "Copy",
+    msgCopied: "Copied",
+    msgCopyFailed: "Copy failed",
+    msgNothingToCopy: "Nothing to copy",
+    msgReply: "Reply",
+    msgForward: "Forward",
+    msgForwardTitle: "Forward to...",
+    msgForwarded: "Forwarded",
+    msgForwardFailed: "Forward failed",
+    msgNoForwardTargets: "No conversations to forward to",
+    msgSelect: "Select",
+    msgDelete: "Delete",
+    msgDeleted: "message deleted",
+    msgDeletedToast: "Message deleted",
+    msgRecall: "Recall",
+    msgRecalled: "message recalled",
+    msgYouRecalled: "You recalled a message",
+    msgRecalledToast: "Message recalled",
+    msgRecallFailed: "Recall failed",
+    msgResend: "Resend",
+    msgCancelReply: "Cancel reply",
+    msgActionFailed: "Action failed",
+    // T14: Status & presence
+    statusSending: "Sending...",
+    statusSent: "Sent",
+    statusDelivered: "Delivered",
+    statusRead: "Read",
+    statusFailed: "Failed to send",
+    connectionConnected: "Connected",
+    connectionReconnecting: "Reconnecting...",
+    connectionDisconnected: "Disconnected",
+    lastSeenJustNow: "Last seen just now",
+    lastSeenMinAgo: "Last seen %d min ago",
+    lastSeenHoursAgo: "Last seen %d hours ago",
+    lastSeenToday: "Last seen today at",
+    lastSeenYesterday: "Last seen yesterday at",
+    lastSeenDate: "Last seen",
+    typingIndicator: "Typing"
   },
   zh: {
     account_details: "账号详情",
@@ -2105,7 +3333,74 @@ const translations = {
     menu_add_account: "添加账号",
     menu_more: "更多",
     menu_about: "关于 iChat Pro",
-    menu_updates: "检查更新"
+    menu_updates: "检查更新",
+    // T12: Conversation actions
+    convPin: "置顶",
+    convUnpin: "取消置顶",
+    convPinned: "已置顶",
+    convUnpinned: "已取消置顶",
+    convMute: "静音",
+    convUnmute: "取消静音",
+    convMuted: "已静音",
+    convUnmuted: "已取消静音",
+    convMute1h: "静音1小时",
+    convMute8h: "静音8小时",
+    convMute24h: "静音24小时",
+    convMuteForever: "永久静音",
+    convArchive: "归档",
+    convUnarchive: "取消归档",
+    convArchived: "已归档",
+    convUnarchived: "已取消归档",
+    convClear: "清空聊天记录",
+    convDelete: "删除会话",
+    convMarkRead: "标为已读",
+    convMarkUnread: "标为未读",
+    convMarkedRead: "已标为已读",
+    convMarkedUnread: "已标为未读",
+    convCleared: "聊天记录已清空",
+    convDeleted: "会话已删除",
+    convClearConfirm: "确定清空该会话的所有消息？",
+    convDeleteConfirm: "确定删除该会话？",
+    convActionFailed: "操作失败",
+    // T13: Message actions
+    msgCopy: "复制",
+    msgCopied: "已复制",
+    msgCopyFailed: "复制失败",
+    msgNothingToCopy: "无可复制内容",
+    msgReply: "回复",
+    msgForward: "转发",
+    msgForwardTitle: "转发到...",
+    msgForwarded: "已转发",
+    msgForwardFailed: "转发失败",
+    msgNoForwardTargets: "没有可转发的会话",
+    msgSelect: "选择",
+    msgDelete: "删除",
+    msgDeleted: "消息已删除",
+    msgDeletedToast: "消息已删除",
+    msgRecall: "撤回",
+    msgRecalled: "消息已撤回",
+    msgYouRecalled: "你撤回了一条消息",
+    msgRecalledToast: "消息已撤回",
+    msgRecallFailed: "撤回失败",
+    msgResend: "重发",
+    msgCancelReply: "取消回复",
+    msgActionFailed: "操作失败",
+    // T14: Status & presence
+    statusSending: "发送中...",
+    statusSent: "已发送",
+    statusDelivered: "已送达",
+    statusRead: "已读",
+    statusFailed: "发送失败",
+    connectionConnected: "已连接",
+    connectionReconnecting: "重连中...",
+    connectionDisconnected: "已断开",
+    lastSeenJustNow: "刚刚在线",
+    lastSeenMinAgo: "最后上线 %d 分钟前",
+    lastSeenHoursAgo: "最后上线 %d 小时前",
+    lastSeenToday: "最后上线今天",
+    lastSeenYesterday: "最后上线昨天",
+    lastSeenDate: "最后上线",
+    typingIndicator: "正在输入"
   }
 };
 

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -1,0 +1,218 @@
+/**
+ * iChat Pro — Reusable Context Menu Component
+ *
+ * Singleton right-click / long-press context menu.
+ * Shared by conversation sidebar items (T12) and message bubbles (T13).
+ *
+ * Usage:
+ *   ContextMenu.show(x, y, [
+ *     { icon: 'pin', label: 'Pin', onClick: () => { ... } },
+ *     { icon: 'trash-2', label: 'Delete', danger: true, onClick: () => { ... } },
+ *     { divider: true },
+ *     { icon: 'check', label: 'Mark as Read', onClick: () => { ... } },
+ *   ]);
+ *   ContextMenu.hide();
+ */
+
+(function () {
+  'use strict';
+
+  let backdropEl = null;
+  let menuEl = null;
+  let visible = false;
+
+  function ensureDOM() {
+    if (backdropEl && menuEl) return;
+
+    // Backdrop — transparent full‑screen overlay to capture outside clicks
+    backdropEl = document.createElement('div');
+    backdropEl.className = 'context-menu-backdrop';
+    backdropEl.addEventListener('click', hide);
+    backdropEl.addEventListener('contextmenu', function (e) {
+      e.preventDefault();
+      hide();
+    });
+    document.body.appendChild(backdropEl);
+
+    // Menu container
+    menuEl = document.createElement('div');
+    menuEl.className = 'context-menu';
+    menuEl.setAttribute('role', 'menu');
+    menuEl.setAttribute('tabindex', '-1');
+    document.body.appendChild(menuEl);
+
+    // Global keyboard handler
+    document.addEventListener('keydown', onKeyDown);
+  }
+
+  function onKeyDown(e) {
+    if (!visible) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      hide();
+    }
+    // Arrow-key navigation
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      const items = menuEl.querySelectorAll('.context-menu-item:not(.context-menu-divider)');
+      if (items.length === 0) return;
+      const focused = menuEl.querySelector('.context-menu-item.focused');
+      let idx = -1;
+      if (focused) {
+        focused.classList.remove('focused');
+        idx = Array.from(items).indexOf(focused);
+      }
+      if (e.key === 'ArrowDown') idx = (idx + 1) % items.length;
+      else idx = (idx - 1 + items.length) % items.length;
+      items[idx].classList.add('focused');
+      items[idx].focus();
+    }
+    if (e.key === 'Enter' && visible) {
+      e.preventDefault();
+      const focused = menuEl.querySelector('.context-menu-item.focused');
+      if (focused) focused.click();
+    }
+  }
+
+  function hide() {
+    if (!visible) return;
+    visible = false;
+    backdropEl.style.display = 'none';
+    menuEl.classList.remove('context-menu-visible');
+    menuEl.innerHTML = '';
+  }
+
+  /**
+   * Show the context menu at the given viewport coordinates.
+   *
+   * @param {number} x  — clientX (left edge of menu)
+   * @param {number} y  — clientY (top edge of menu)
+   * @param {Array}  items
+   *   Each item: { icon?, label, danger?, onClick, divider?: true }
+   *   A divider-only entry: { divider: true }
+   */
+  function show(x, y, items) {
+    if (!items || items.length === 0) return;
+    ensureDOM();
+
+    // Build menu HTML
+    let html = '';
+    items.forEach(function (item) {
+      if (item.divider) {
+        html += '<div class="context-menu-divider" role="separator"></div>';
+        return;
+      }
+      var dangerClass = item.danger ? ' danger' : '';
+      var iconHtml = item.icon
+        ? '<i data-lucide="' + escapeAttr(item.icon) + '" class="context-menu-item-icon"></i>'
+        : '<span class="context-menu-item-icon"></span>'; // placeholder for alignment
+      html +=
+        '<button class="context-menu-item' + dangerClass + '" role="menuitem" tabindex="-1">' +
+        iconHtml +
+        '<span class="context-menu-item-label">' + escapeHtml(item.label) + '</span>' +
+        '</button>';
+    });
+
+    menuEl.innerHTML = html;
+
+    // Bind click handlers
+    var buttons = menuEl.querySelectorAll('.context-menu-item');
+    items.forEach(function (item, idx) {
+      if (item.divider) return;
+      var btn = buttons[Array.from(menuEl.querySelectorAll('.context-menu-item')).indexOf(buttons[idx > 0 ? idx : 0])];
+      // More reliable: map filtered items to buttons
+    });
+
+    // Re-bind cleanly
+    var filteredItems = items.filter(function (it) { return !it.divider; });
+    var allButtons = menuEl.querySelectorAll('.context-menu-item');
+    allButtons.forEach(function (btn, i) {
+      var item = filteredItems[i];
+      if (!item) return;
+      btn.addEventListener('click', function (e) {
+        e.stopPropagation();
+        hide();
+        if (typeof item.onClick === 'function') item.onClick();
+      });
+      btn.addEventListener('mouseenter', function () {
+        allButtons.forEach(function (b) { b.classList.remove('focused'); });
+        btn.classList.add('focused');
+      });
+    });
+
+    // Render icons
+    if (window.lucide && window.lucide.createIcons) {
+      window.lucide.createIcons({ nodes: menuEl.querySelectorAll('[data-lucide]') });
+    }
+
+    // Show
+    visible = true;
+    backdropEl.style.display = 'block';
+
+    // Position: first render off‑screen to measure
+    menuEl.style.visibility = 'hidden';
+    menuEl.style.left = '0px';
+    menuEl.style.top = '0px';
+    menuEl.classList.add('context-menu-visible');
+
+    // Measure and reposition
+    var menuW = menuEl.offsetWidth;
+    var menuH = menuEl.offsetHeight;
+    var vw = window.innerWidth;
+    var vh = window.innerHeight;
+
+    var left = x;
+    var top = y;
+
+    // Flip horizontally if it would overflow right edge
+    if (left + menuW > vw - 8) {
+      left = x - menuW;
+    }
+    if (left < 8) left = 8;
+
+    // Flip vertically if it would overflow bottom edge
+    if (top + menuH > vh - 8) {
+      top = y - menuH;
+    }
+    if (top < 8) top = 8;
+
+    menuEl.style.left = left + 'px';
+    menuEl.style.top = top + 'px';
+    menuEl.style.visibility = 'visible';
+
+    // Focus first item for keyboard nav
+    if (allButtons.length > 0) {
+      allButtons[0].classList.add('focused');
+    }
+  }
+
+  // --- Helpers (self‑contained, no external deps) ---
+
+  function escapeHtml(str) {
+    return String(str || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function escapeAttr(str) {
+    return String(str || '').replace(/"/g, '&quot;');
+  }
+
+  // --- Global scroll / resize cleanup ---
+  window.addEventListener('scroll', function () {
+    if (visible) hide();
+  }, true); // capture phase to catch message-container scroll
+
+  window.addEventListener('resize', function () {
+    if (visible) hide();
+  });
+
+  // --- Public API ---
+  window.ContextMenu = {
+    show: show,
+    hide: hide,
+  };
+})();

--- a/templates/components/chat_window.html
+++ b/templates/components/chat_window.html
@@ -166,6 +166,12 @@
         
         <h3 class="text-base font-bold text-textMain" data-i18n="verify_fp_title">Verify Security Fingerprint</h3>
         <p class="text-xs text-textSecondary mt-1" data-i18n="verify_fp_desc">Comparing keys prevents potential interception.</p>
+        <div id="fp-modal-status" class="security-status-chip security-status-loading mt-3">
+          Loading trust status
+        </div>
+        <div id="fp-modal-warning" class="hidden mt-3 w-full rounded-custom-md border border-red-500/25 bg-red-500/10 px-3 py-2 text-left text-xs font-semibold text-red-600 dark:text-red-400">
+          High risk: this contact active key differs from a previously verified fingerprint.
+        </div>
 
         <!-- Mock QR code pattern -->
         <div class="my-5 p-2 bg-white rounded-lg border border-gray-200">
@@ -194,10 +200,18 @@
           </code>
         </div>
 
-        <!-- Confirmation control button -->
-        <button onclick="closeFingerprintModal()"
+        <!-- Trust controls -->
+        <button id="fp-modal-trust-btn" onclick="trustActiveFingerprintFromModal()"
           class="w-full mt-5 py-2.5 bg-brand-light dark:bg-brand-dark text-white font-semibold text-sm rounded-custom-md hover:opacity-95 focus:outline-none transition-all">
-          <span data-i18n="fp_match_btn">Fingerprints Match</span>
+          Fingerprints Match
+        </button>
+        <button id="fp-modal-untrust-btn" onclick="untrustActiveFingerprintFromModal()"
+          class="hidden w-full mt-2 py-2.5 border border-borderColor text-textSecondary hover:text-red-500 hover:border-red-500/40 font-semibold text-sm rounded-custom-md focus:outline-none transition-all">
+          Remove Trust
+        </button>
+        <button onclick="closeFingerprintModal()"
+          class="w-full mt-2 py-2 text-textSecondary hover:text-textMain font-semibold text-xs rounded-custom-md hover:bg-bgSearch focus:outline-none transition-all">
+          Close
         </button>
 
       </div>

--- a/templates/components/settings_panel_body.html
+++ b/templates/components/settings_panel_body.html
@@ -123,6 +123,16 @@
           <code id="key-fingerprint-display" class="block w-full px-3 py-2 rounded-custom-md bg-bgSearch border border-borderColor text-[11px] font-mono text-textMain break-all select-all">—</code>
         </div>
         <div class="grid grid-cols-2 gap-2">
+          <div class="p-2.5 bg-bgSearch rounded-custom-md border border-borderColor/60">
+            <div class="text-[10px] text-textSecondary">Active Key Version</div>
+            <div id="key-version-display" class="text-sm font-bold text-textMain mt-0.5">-</div>
+          </div>
+          <div class="p-2.5 bg-bgSearch rounded-custom-md border border-borderColor/60">
+            <div class="text-[10px] text-textSecondary">Trusted By</div>
+            <div id="key-trusted-by-display" class="text-sm font-bold text-textMain mt-0.5">-</div>
+          </div>
+        </div>
+        <div class="grid grid-cols-2 gap-2">
           <button id="btn-key-generate" class="py-2 px-3 text-xs font-semibold rounded-custom-md bg-brand-light dark:bg-brand-dark text-white hover:opacity-90 transition-opacity" onclick="keyMgrGenerate()">Generate Keys</button>
           <button id="btn-key-upload" class="py-2 px-3 text-xs font-semibold rounded-custom-md border border-brand-light dark:border-brand-dark text-brand-light dark:text-brand-dark hover:bg-brand-light/10 transition-colors" onclick="keyMgrUpload()">Upload to Server</button>
           <button id="btn-key-export" class="py-2 px-3 text-xs font-semibold rounded-custom-md border border-borderColor text-textMain hover:bg-bgSearch transition-colors" onclick="keyMgrExport()">Export Backup</button>
@@ -147,7 +157,7 @@
         <i id="security-status-chevron" data-lucide="chevron-down" class="w-4 h-4 text-textSecondary transition-transform"></i>
       </button>
       <div id="security-status-panel" class="hidden mt-3 px-1 space-y-3">
-        <div class="grid grid-cols-2 gap-2">
+        <div class="grid grid-cols-3 gap-2">
           <div class="p-3 bg-bgSearch rounded-custom-md text-center">
             <div id="sec-keys-status" class="text-lg font-bold text-green-500">-</div>
             <div class="text-[10px] text-textSecondary mt-0.5">Local Keys</div>
@@ -156,7 +166,12 @@
             <div id="sec-server-status" class="text-lg font-bold text-gray-400">-</div>
             <div class="text-[10px] text-textSecondary mt-0.5">Server Synced</div>
           </div>
+          <div class="p-3 bg-bgSearch rounded-custom-md text-center">
+            <div id="sec-trust-status" class="text-lg font-bold text-gray-400">-</div>
+            <div class="text-[10px] text-textSecondary mt-0.5">Verified Contacts</div>
+          </div>
         </div>
+        <div id="security-trust-list" class="space-y-2"></div>
         <button onclick="refreshSecurityStatus()" class="w-full py-2 text-xs font-medium text-brand-light dark:text-brand-dark hover:underline">Refresh Status</button>
       </div>
     </div>

--- a/templates/components/sidebar.html
+++ b/templates/components/sidebar.html
@@ -110,9 +110,11 @@
           <i data-lucide="search" class="w-4 h-4"></i>
         </span>
         <input type="text" id="sidebar-search" 
-          class="w-full pl-10 pr-4 py-2 rounded-full bg-bgSearch text-textMain border border-transparent placeholder-textSecondary/65 focus:outline-none focus:ring-2 focus:ring-brand-light dark:focus:ring-brand-dark focus:bg-bgMain text-sm transition-all"
+          class="w-full pl-10 pr-4 py-2 rounded-full bg-bgSearch text-textMain border border-transparent placeholder-textSecondary/65 focus:outline-none focus:ring-2 focus:ring-brand-light dark:focus:ring-brand-dark focus:bg-bgMain text-sm transition-all cursor-pointer"
           placeholder="Search chats or messages..."
-          data-i18n-placeholder="search_placeholder">
+          data-i18n-placeholder="search_placeholder"
+          onfocus="navigateSidebar('search'); setTimeout(function(){ var si=document.getElementById('search-sidebar-input'); if(si) si.focus(); }, 100);"
+          readonly>
       </div>
     </div>
     
@@ -156,16 +158,50 @@
     </div>
   </div>
 
-  <!-- View 3: Contacts View -->
-  <div id="sidebar-view-contacts" class="sidebar-view hidden h-full flex flex-col bg-bgSidebar">
+  <!-- View 3: Contacts View (P2 T09) -->
+  <div id="sidebar-view-contacts" class="sidebar-view hidden h-full flex flex-col bg-bgSidebar relative">
     <div class="px-4 py-3 border-b border-borderColor flex items-center space-x-3 flex-shrink-0" style="min-height: 57px;">
       <button onclick="navigateSidebar('chat')" class="p-1.5 rounded-full hover:bg-bgSearch text-textMain transition-all" title="Back to Chats" data-i18n-title="back_to_sidebar">
         <i data-lucide="arrow-left" class="w-5 h-5"></i>
       </button>
-      <h2 class="text-lg font-bold text-textMain flex-1" data-i18n="menu_contacts">Contacts</h2>
+      <div class="relative flex-1">
+        <span class="absolute inset-y-0 left-0 pl-3 flex items-center text-textSecondary pointer-events-none">
+          <i data-lucide="search" class="w-4 h-4"></i>
+        </span>
+        <input type="text" id="contacts-header-search"
+          class="w-full pl-9 pr-4 py-2 rounded-full bg-bgSearch text-textMain border border-transparent placeholder-textSecondary/65 focus:outline-none focus:ring-2 focus:ring-brand-light dark:focus:ring-brand-dark focus:bg-bgMain text-sm transition-all"
+          placeholder="Search contacts..."
+          oninput="filterContactsInSidebar(this.value)">
+      </div>
     </div>
     <div class="flex-1 overflow-y-auto custom-scrollbar" id="sidebar-contacts-content">
       {% include 'pages/contacts_sidebar.html' %}
+    </div>
+
+    <!-- FAB: Quick Create Menu (P2 T09) -->
+    <div class="absolute bottom-5 right-5 z-20" id="contacts-fab-container">
+      <button id="contacts-fab-btn" onclick="toggleContactsFab(event)"
+        class="w-12 h-12 rounded-full bg-brand-light dark:bg-brand-dark text-white shadow-lg flex items-center justify-center transition-all duration-200 hover:scale-105 focus:outline-none"
+        title="Quick create">
+        <i data-lucide="plus" class="w-6 h-6 transition-transform duration-200" id="contacts-fab-icon"></i>
+      </button>
+      <!-- FAB Menu Dropdown -->
+      <div id="contacts-fab-menu" class="hidden absolute bottom-14 right-0 w-52 bg-bgSidebar/95 dark:bg-bgSidebar/98 backdrop-blur-lg border border-borderColor/60 rounded-[18px] shadow-xl z-30 py-1.5 animate-fadeIn">
+        <button onclick="fabNewPrivateChat(event)" class="fab-menu-item">
+          <i data-lucide="message-circle" class="w-4 h-4 text-brand-light dark:text-brand-dark"></i>
+          <span>New Private Chat</span>
+        </button>
+        <button onclick="fabNewGroup(event)" class="fab-menu-item">
+          <i data-lucide="users" class="w-4 h-4 text-green-500"></i>
+          <span>New Group</span>
+        </button>
+        <div class="h-px bg-borderColor/40 my-1"></div>
+        <button onclick="fabNewChannel(event)" class="fab-menu-item opacity-50 cursor-not-allowed">
+          <i data-lucide="hash" class="w-4 h-4"></i>
+          <span>New Channel</span>
+          <span class="text-[10px] text-textSecondary ml-auto">Soon</span>
+        </button>
+      </div>
     </div>
   </div>
 
@@ -182,16 +218,59 @@
     </div>
   </div>
 
-  <!-- View 6: Search Results View -->
+  <!-- View 6: Search Results View (P2 T10) -->
   <div id="sidebar-view-search" class="sidebar-view hidden h-full flex flex-col bg-bgSidebar">
-    <div class="px-4 py-3 border-b border-borderColor flex items-center space-x-3 flex-shrink-0" style="min-height: 57px;">
+    <!-- Header: back + search input + clear -->
+    <div class="px-4 py-3 border-b border-borderColor flex items-center space-x-3 flex-shrink-0" style="min-height:57px">
       <button onclick="navigateSidebar('chat')" class="p-1.5 rounded-full hover:bg-bgSearch text-textMain transition-all" title="Back to Chats" data-i18n-title="back_to_sidebar">
         <i data-lucide="arrow-left" class="w-5 h-5"></i>
       </button>
-      <h2 class="text-lg font-bold text-textMain flex-1">Search</h2>
+      <div class="relative flex-1">
+        <span class="absolute inset-y-0 left-0 pl-3 flex items-center text-textSecondary pointer-events-none">
+          <i data-lucide="search" class="w-4 h-4"></i>
+        </span>
+        <input type="text" id="search-sidebar-input"
+          class="w-full pl-9 pr-9 py-2 rounded-full bg-bgSearch text-textMain border border-transparent placeholder-textSecondary/65 focus:outline-none focus:ring-2 focus:ring-brand-light dark:focus:ring-brand-dark text-sm"
+          placeholder="Search..."
+          autocomplete="off">
+        <button id="search-sidebar-clear" class="hidden absolute inset-y-0 right-0 pr-2.5 flex items-center text-textSecondary hover:text-textMain"
+          onclick="clearSearchSidebar()">
+          <i data-lucide="x" class="w-4 h-4"></i>
+        </button>
+      </div>
     </div>
-    <div class="flex-1 overflow-y-auto custom-scrollbar" id="sidebar-search-results">
-      <p class="text-textSecondary text-sm text-center py-8">Type in the search bar above to find chats and messages.</p>
+
+    <!-- Type tabs: Chats | Channels | Apps | Posts -->
+    <div class="px-4 py-2 border-b border-borderColor/60 flex-shrink-0 overflow-x-auto search-type-tabs">
+      <div class="flex space-x-1 min-w-max">
+        <button class="search-type-tab active" data-tab="chats" onclick="switchSearchTab('chats')">Chats</button>
+        <button class="search-type-tab" data-tab="channels" onclick="switchSearchTab('channels')">Channels</button>
+        <button class="search-type-tab" data-tab="apps" onclick="switchSearchTab('apps')">Apps</button>
+        <button class="search-type-tab" data-tab="posts" onclick="switchSearchTab('posts')">Posts</button>
+      </div>
+    </div>
+
+    <!-- Scope filter (shown for chats tab, hidden for others) -->
+    <div id="search-scope-bar" class="px-4 py-2 border-b border-borderColor/60 flex-shrink-0">
+      <select id="search-scope-select" onchange="onSearchScopeChange()"
+        class="w-full text-xs bg-bgSearch border border-borderColor rounded-full px-3 py-1.5 text-textMain focus:outline-none focus:ring-1 focus:ring-brand-light dark:focus:ring-brand-dark">
+        <option value="all">All Chats</option>
+        <option value="private_chats">Private Chats</option>
+        <option value="group_chats">Group Chats</option>
+        <option value="channels">Channels</option>
+      </select>
+    </div>
+
+    <!-- Results area -->
+    <div class="flex-1 overflow-y-auto custom-scrollbar" id="search-results-container">
+      <div id="search-empty-state" class="flex flex-col items-center justify-center h-full text-textSecondary">
+        <i data-lucide="search" class="w-10 h-10 mb-3 opacity-30"></i>
+        <p class="text-sm">Search for chats, contacts, and messages</p>
+      </div>
+      <div id="search-results-content" class="hidden divide-y divide-borderColor/30"></div>
+      <div id="search-loading" class="hidden flex items-center justify-center py-8">
+        <div class="animate-spin w-5 h-5 border-2 border-brand-light border-t-transparent rounded-full"></div>
+      </div>
     </div>
   </div>
 

--- a/templates/pages/chat.html
+++ b/templates/pages/chat.html
@@ -187,7 +187,10 @@
 <script id="ichat-key-manager-script" src="{% static 'js/key-manager.js' %}?v=20260609-explicit-key-reset" data-current-user-id="{{ request.user.pk }}"></script>
 <script src="{% static 'js/private-chat-e2ee.js' %}?v=20260609-peer-trust-reset"></script>
 <script src="{% static 'js/group-chat-e2ee.js' %}"></script>
-<script src="{% static 'js/chat.js' %}?v=20260609-decrypt-error-copy"></script>
+<script src="{% static 'js/context-menu.js' %}?v=20260610-t12t14-chat-ux"></script>
+<script src="{% static 'js/chat-conversation-actions.js' %}?v=20260610-t12t14-chat-ux"></script>
+<script src="{% static 'js/chat-message-actions.js' %}?v=20260610-t12t14-chat-ux"></script>
+<script src="{% static 'js/chat.js' %}?v=20260610-t12t14-chat-ux"></script>
 <script>
   function exportLocalKeyBackup() {
     try {

--- a/templates/pages/contacts_sidebar.html
+++ b/templates/pages/contacts_sidebar.html
@@ -44,7 +44,7 @@
     </h3>
     <div class="space-y-2">
       {% for req in incoming_requests %}
-      <div class="flex items-center justify-between p-3 bg-bgSearch rounded-custom-md">
+      <div class="flex items-center justify-between p-3 bg-bgSearch rounded-custom-md" data-contact-search="{{ req.sender.username }}">
         <div>
           <p class="text-sm font-semibold text-textMain">{{ req.sender.username }}</p>
           <p class="text-[10px] text-textSecondary">{{ req.created_at|date:"M d" }}</p>
@@ -73,7 +73,7 @@
     </h3>
     <div class="space-y-2">
       {% for req in outgoing_requests %}
-      <div class="flex items-center justify-between p-3 bg-bgSearch rounded-custom-md">
+      <div class="flex items-center justify-between p-3 bg-bgSearch rounded-custom-md" data-contact-search="{{ req.receiver.username }}">
         <div>
           <p class="text-sm font-semibold text-textMain">{{ req.receiver.username }}</p>
           <p class="text-[10px] text-textSecondary">Pending</p>
@@ -92,14 +92,14 @@
     {% if contacts %}
     <div class="space-y-2">
       {% for entry in contacts %}
-      <div class="flex items-center justify-between p-3 bg-bgSearch rounded-custom-md">
+      <div class="flex items-center justify-between p-3 bg-bgSearch rounded-custom-md" data-contact-search="{% if entry.user == request.user %}{{ entry.contact.username }}{% else %}{{ entry.user.username }}{% endif %}">
         {% if entry.user == request.user %}
           {% with peer=entry.contact %}
-        <div class="flex items-center space-x-3">
-          <div class="w-10 h-10 rounded-full bg-brand-light dark:bg-brand-dark text-white flex items-center justify-center font-bold text-sm">
+        <div class="flex items-center space-x-3 flex-1 min-w-0">
+          <div class="w-10 h-10 rounded-full bg-brand-light dark:bg-brand-dark text-white flex items-center justify-center font-bold text-sm flex-shrink-0">
             {{ peer.username|slice:":1"|upper }}
           </div>
-          <div>
+          <div class="min-w-0">
             <p class="text-sm font-semibold text-textMain">{{ peer.username }}</p>
             <p class="text-[10px] text-textSecondary">Contact since {{ entry.created_at|date:"M d, Y" }}</p>
           </div>
@@ -107,11 +107,11 @@
           {% endwith %}
         {% else %}
           {% with peer=entry.user %}
-        <div class="flex items-center space-x-3">
-          <div class="w-10 h-10 rounded-full bg-brand-light dark:bg-brand-dark text-white flex items-center justify-center font-bold text-sm">
+        <div class="flex items-center space-x-3 flex-1 min-w-0">
+          <div class="w-10 h-10 rounded-full bg-brand-light dark:bg-brand-dark text-white flex items-center justify-center font-bold text-sm flex-shrink-0">
             {{ peer.username|slice:":1"|upper }}
           </div>
-          <div>
+          <div class="min-w-0">
             <p class="text-sm font-semibold text-textMain">{{ peer.username }}</p>
             <p class="text-[10px] text-textSecondary">Contact since {{ entry.created_at|date:"M d, Y" }}</p>
           </div>


### PR DESCRIPTION
## Summary

- **T09**: Contacts sidebar + FAB quick-create menu (new private chat, new group, new channel placeholder)
- **T10**: Search sidebar with type tabs (Chats/Channels/Apps/Posts), scope filter, debounced search, result grouping
- **T12**: Reusable context menu component + conversation actions (pin/unpin, mute/unmute, archive/unarchive, clear history, delete, mark read/unread)
- **T13**: Message actions (copy, reply with quote banner, forward, local delete, recall within window, resend failed, select mode)
- **T14**: Read receipts, online/last-seen presence, typing indicator, WebSocket connection status badge
- **T16**: Key fingerprint verification modal with trust/untrust controls, key-change high-risk warning, security status panel with verified contacts list

## Files Changed (11)

| File | Change |
|---|---|
| `static/js/chat.js` | Core engine: T09 FAB handlers, T10 search logic, T14 presence/typing/receipts/connection, T16 key trust API integration |
| `static/js/context-menu.js` | New — reusable singleton context menu component (T12/T13) |
| `static/js/chat-conversation-actions.js` | New — conversation context-menu handlers (T12) |
| `static/js/chat-message-actions.js` | New — message context-menu handlers (T13) |
| `static/css/chat.css` | Styles for security chips, trust rows, context menu, reply quote, typing dots, connection badge, message status, search results (T09/T10/T12/T13/T14/T16) |
| `templates/components/sidebar.html` | Contacts view with FAB, search view with type tabs + scope filter (T09/T10) |
| `templates/pages/contacts_sidebar.html` | `data-contact-search` attributes for sidebar filtering (T09) |
| `templates/components/chat_window.html` | Fingerprint modal trust controls + key-change warning (T16) |
| `templates/components/settings_panel_body.html` | Key version/trusted-by display, security status panel with trust list (T16) |
| `templates/pages/chat.html` | Cache-bust version update for chat.js |
| `chat/views.py` | Minor: pass `membership_version` in forward payload |

## Validation

```
node --check static/js/chat.js static/js/context-menu.js static/js/chat-conversation-actions.js static/js/chat-message-actions.js
python manage.py check
python manage.py test chat.test_p2_issues.KeyTrustTests
```

## Not in this PR

- **T11** (multi-account UI) — pending backend P2 T35/T36
- **T15** (group management UI) — pending backend P2 T37
- **T17** (unified profile/avatar display) — pending backend P2 T29/T31/T39

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)