### PR TITLE
[codex] P2 T11: Multi-Account Add & Switch UI

### DIFF
--- a/accounts/views.py
+++ b/accounts/views.py
@@ -13,6 +13,7 @@ from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.http import require_GET, require_POST, require_http_methods
 
 from chat.models import Conversation, ConversationMember as ChatMember
@@ -124,6 +125,13 @@ def register_view(request):
     return render(request, 'pages/register.html', {'form': form})
 
 
+def _safe_next_url(next_url, fallback='index'):
+    """Return next_url if it is a safe same-site path, otherwise fallback."""
+    if next_url and url_has_allowed_host_and_scheme(next_url, allowed_hosts=None):
+        return next_url
+    return fallback
+
+
 def login_view(request):
     if request.user.is_authenticated:
         return redirect('index')
@@ -152,7 +160,10 @@ def login_view(request):
                     request,
                     f'Welcome back, {user.get_short_name() or username}!',
                 )
-                return redirect('index')
+                next_url = _safe_next_url(
+                    request.POST.get('next') or request.GET.get('next') or '',
+                )
+                return redirect(next_url)
 
             # credentials were valid format but authenticate returned None
             if target is not None:
@@ -207,7 +218,8 @@ def login_view(request):
 def logout_view(request):
     logout(request)
     messages.info(request, 'You have been logged out.')
-    return redirect('login')
+    next_url = _safe_next_url(request.GET.get('next') or '', fallback='login')
+    return redirect(next_url)
 
 
 # ── Contact & Friend-request views ──────────────────────────────────

--- a/static/css/chat.css
+++ b/static/css/chat.css
@@ -1957,6 +1957,51 @@ input:checked + .slider:before {
   background-color: rgba(255, 255, 255, 0.03);
 }
 
+/* ==========================================================================
+   P2 T11: Multi-Account Card Styles
+   ========================================================================== */
+
+.account-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--radius-lg, 14px);
+  border: 1px solid var(--color-border);
+  background: var(--color-sidebar-bg);
+  transition: background-color 0.15s, border-color 0.15s;
+  cursor: default;
+}
+
+.account-card:hover {
+  background: var(--color-search-bg);
+}
+
+.account-card-current {
+  border-color: var(--color-primary);
+  background: rgba(99, 102, 241, 0.06);
+}
+
+.account-card-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--color-primary), #7c3aed);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 1rem;
+  flex-shrink: 0;
+}
+
+.account-add-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* Top-Right and Top-Left Buttons Active and Hover Highlighting */
 #chat-header-more-btn:hover,
 #chat-header-more-btn.active,

--- a/static/js/chat.js
+++ b/static/js/chat.js
@@ -2374,7 +2374,8 @@ function navigateSidebar(viewName) {
     'privacy-security',
     'general-settings',
     'chat-folders',
-    'sessions-shortcuts'
+    'sessions-shortcuts',
+    'accounts-switcher'
   ];
   views.forEach(function(name) {
     var el = name === 'chat'
@@ -2396,6 +2397,10 @@ function navigateSidebar(viewName) {
   if (viewName === 'privacy-security' && typeof loadPrivacySettings === 'function') {
     setTimeout(function() { loadPrivacySettings(); }, 150);
   }
+  // Refresh account switcher list when navigating to it (P2 T11)
+  if (viewName === 'accounts-switcher') {
+    setTimeout(function() { renderAccountsSwitcher(); }, 50);
+  }
   // Re-render lucide icons after view switch
   if (window.lucide) setTimeout(function() { lucide.createIcons(); }, 50);
 }
@@ -2407,6 +2412,142 @@ function showSettingsPanel() {
 
 function hideSettingsPanel() {
   navigateSidebar('chat');
+}
+
+// ============================================================================
+// P2 T11: Multi-Account Add & Switch
+// ============================================================================
+
+function getSavedAccounts() {
+  try {
+    return JSON.parse(localStorage.getItem('ichat_accounts') || '[]');
+  } catch (e) {
+    return [];
+  }
+}
+
+function saveAccountToLocalList(user) {
+  if (!user || !user.username) return;
+  var accounts = getSavedAccounts();
+  // Remove existing entry for this username (dedup)
+  accounts = accounts.filter(function(a) { return a.username !== user.username; });
+  // Add to front
+  accounts.unshift({
+    username: user.username,
+    initials: user.initials || user.username[0].toUpperCase(),
+    email: user.email || '',
+    addedAt: Date.now()
+  });
+  // Keep max 10 accounts
+  if (accounts.length > 10) accounts = accounts.slice(0, 10);
+  try {
+    localStorage.setItem('ichat_accounts', JSON.stringify(accounts));
+  } catch (e) {
+    // localStorage full or unavailable
+  }
+}
+
+function removeSavedAccount(username) {
+  var accounts = getSavedAccounts().filter(function(a) { return a.username !== username; });
+  try {
+    localStorage.setItem('ichat_accounts', JSON.stringify(accounts));
+  } catch (e) {}
+}
+
+function autoSaveCurrentAccount() {
+  var keyScript = document.getElementById('ichat-key-manager-script');
+  if (!keyScript) return;
+  var username = keyScript.dataset.username;
+  if (!username) return;
+  var initials = username[0].toUpperCase();
+  var email = keyScript.dataset.email || '';
+  saveAccountToLocalList({ username: username, initials: initials, email: email });
+
+  // If coming from 'add account' flow, clear the URL param
+  var params = new URLSearchParams(window.location.search);
+  if (params.get('add_account') === '1') {
+    params.delete('add_account');
+    var newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+    if (window.history && window.history.replaceState) {
+      window.history.replaceState({}, '', newUrl);
+    }
+  }
+}
+
+function renderAccountsSwitcher() {
+  var list = document.getElementById('accounts-switcher-list');
+  if (!list) return;
+  var accounts = getSavedAccounts();
+  var keyScript = document.getElementById('ichat-key-manager-script');
+  var currentUsername = keyScript ? keyScript.dataset.username : '';
+
+  list.innerHTML = '';
+
+  if (!accounts.length) {
+    list.innerHTML = '<div class="text-xs text-textSecondary text-center py-8">' +
+      (currentLanguage === 'zh' ? '暂无已保存的账号。点击下方按钮添加新账号。' : 'No saved accounts. Tap below to add one.') +
+      '</div>';
+    return;
+  }
+
+  accounts.forEach(function(acc) {
+    var isCurrent = acc.username === currentUsername;
+    var card = document.createElement('div');
+    card.className = 'account-card' + (isCurrent ? ' account-card-current' : '');
+    card.innerHTML =
+      '<div class="account-card-avatar">' + escapeHtml(acc.initials) + '</div>' +
+      '<div class="flex-1 min-w-0">' +
+        '<div class="text-sm font-semibold text-textMain truncate">' + escapeHtml(acc.username) +
+          (isCurrent ? ' <span class="text-[10px] text-brand-light dark:text-brand-dark font-medium ml-1">' + (currentLanguage === 'zh' ? '当前' : 'Current') + '</span>' : '') +
+        '</div>' +
+        '<div class="text-[11px] text-textSecondary truncate">' + (acc.email ? escapeHtml(acc.email) : '') + '</div>' +
+      '</div>';
+
+    if (!isCurrent) {
+      var btn = document.createElement('button');
+      btn.className = 'text-xs font-semibold text-brand-light dark:text-brand-dark hover:underline flex-shrink-0 ml-2';
+      btn.textContent = currentLanguage === 'zh' ? '切换' : 'Switch';
+      btn.onclick = function(e) {
+        e.stopPropagation();
+        switchToAccount(acc.username);
+      };
+      card.appendChild(btn);
+    }
+
+    // Long-press or right-click to remove
+    card.addEventListener('contextmenu', function(e) {
+      e.preventDefault();
+      if (isCurrent) {
+        window.showToast(currentLanguage === 'zh' ? '不能移除当前账号' : 'Cannot remove current account');
+        return;
+      }
+      var confirmMsg = currentLanguage === 'zh'
+        ? '确定从列表中移除账号 "' + acc.username + '" ？'
+        : 'Remove "' + acc.username + '" from the account list?';
+      if (window.confirm(confirmMsg)) {
+        removeSavedAccount(acc.username);
+        renderAccountsSwitcher();
+      }
+    });
+
+    list.appendChild(card);
+  });
+
+  if (window.lucide) window.lucide.createIcons();
+}
+
+function switchToAccount(username) {
+  var msg = currentLanguage === 'zh'
+    ? '切换到账号 "' + username + '" ？当前会话将退出。'
+    : 'Switch to "' + username + '"? You will be logged out of the current account.';
+  if (!window.confirm(msg)) return;
+  // T11: logout then redirect to login to switch accounts
+  window.location.href = '/logout/?next=' + encodeURIComponent('/login/?next=/chat/');
+}
+
+function addNewAccount() {
+  // T11: logout first so login_view won't redirect authenticated users away
+  window.location.href = '/logout/?next=' + encodeURIComponent('/login/?next=/chat/?add_account=1');
 }
 
 // ============================================================================
@@ -3166,6 +3307,9 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   var keyScript = document.getElementById('ichat-key-manager-script');
   myUserId = keyScript ? parseInt(keyScript.dataset.currentUserId) : null;
+
+  // T11: Auto-save current account to multi-account list
+  autoSaveCurrentAccount();
 
   setupEventListeners();
   setupSidebarResizer();
@@ -4519,7 +4663,7 @@ function deleteAccount() {
   showPrivacyConfirmModal(title, desc, async function() {
     try {
       await apiFetch('/api/privacy/delete-account/', { method: 'POST' });
-      window.location.href = '/accounts/login/';
+      window.location.href = '/login/';
     } catch (err) {
       console.error('Failed to delete account:', err);
       window.showToast(currentLanguage === 'zh'

--- a/templates/components/sidebar.html
+++ b/templates/components/sidebar.html
@@ -28,7 +28,7 @@
           <!-- Menu Items -->
           <div class="py-1">
             <!-- Add Account -->
-            <button onclick="showToast(currentLanguage === 'zh' ? '多账号功能暂未开放' : 'Multi-account is not yet available'); toggleMainMenu(event);" class="main-menu-item-custom">
+            <button onclick="navigateSidebar('accounts-switcher'); toggleMainMenu(event);" class="main-menu-item-custom">
               <i data-lucide="plus"></i>
               <span data-i18n="menu_add_account">Add Account</span>
             </button>
@@ -271,6 +271,27 @@
       <div id="search-loading" class="hidden flex items-center justify-center py-8">
         <div class="animate-spin w-5 h-5 border-2 border-brand-light border-t-transparent rounded-full"></div>
       </div>
+    </div>
+  </div>
+
+  <!-- P2 T11: Multi-Account Switcher -->
+  <div id="sidebar-view-accounts-switcher" class="sidebar-view hidden h-full flex flex-col bg-bgSidebar">
+    <div class="px-4 py-3 border-b border-borderColor flex items-center space-x-3 flex-shrink-0" style="min-height:57px">
+      <button onclick="navigateSidebar('chat')" class="p-1.5 rounded-full hover:bg-bgSearch text-textMain transition-all" title="Back to Chats" data-i18n-title="back_to_sidebar">
+        <i data-lucide="arrow-left" class="w-5 h-5"></i>
+      </button>
+      <h2 class="text-lg font-bold text-textMain flex-1" data-i18n="menu_add_account">Accounts</h2>
+      <button onclick="addNewAccount()" class="py-1.5 px-3 text-xs font-semibold rounded-full bg-brand-light dark:bg-brand-dark text-white hover:opacity-90 transition-opacity">
+        <i data-lucide="plus" class="w-3.5 h-3.5 inline mr-1"></i>Add
+      </button>
+    </div>
+    <div class="flex-1 overflow-y-auto custom-scrollbar p-4 space-y-3" id="accounts-switcher-list">
+      <div class="text-xs text-textSecondary text-center py-8">Loading accounts...</div>
+    </div>
+    <div class="p-4 border-t border-borderColor">
+      <button onclick="addNewAccount()" class="account-add-btn w-full py-2.5 px-4 border-2 border-dashed border-borderColor rounded-xl text-textSecondary hover:text-textMain hover:border-brand-light dark:hover:border-brand-dark hover:bg-bgSearch transition-all text-sm font-medium">
+        <i data-lucide="plus" class="w-4 h-4 inline mr-2"></i>Add Another Account
+      </button>
     </div>
   </div>
 

--- a/templates/pages/chat.html
+++ b/templates/pages/chat.html
@@ -184,7 +184,7 @@
 
 {% block extra_js %}
 <!-- Main Chat Interaction JavaScript -->
-<script id="ichat-key-manager-script" src="{% static 'js/key-manager.js' %}?v=20260609-explicit-key-reset" data-current-user-id="{{ request.user.pk }}"></script>
+<script id="ichat-key-manager-script" src="{% static 'js/key-manager.js' %}?v=20260609-explicit-key-reset" data-current-user-id="{{ request.user.pk }}" data-username="{{ request.user.username }}" data-email="{{ request.user.email|default:'' }}"></script>
 <script src="{% static 'js/private-chat-e2ee.js' %}?v=20260609-peer-trust-reset"></script>
 <script src="{% static 'js/group-chat-e2ee.js' %}"></script>
 <script src="{% static 'js/context-menu.js' %}?v=20260610-t12t14-chat-ux"></script>

--- a/templates/pages/login.html
+++ b/templates/pages/login.html
@@ -34,6 +34,7 @@
 
   <form id="login-form" method="POST" action="{% url 'login' %}" class="space-y-5" onsubmit="return handleFormSubmit(event)">
     {% csrf_token %}
+    <input type="hidden" name="next" value="{{ request.GET.next|default:'' }}">
 
     <div class="space-y-1.5">
       <label for="username" class="block text-sm font-semibold text-textMain">Username or Email</label>


### PR DESCRIPTION
## Summary

Implements the multi-account experience — users can see accounts used on this browser, switch between them, and add new ones.

### How it works
- Account list persisted in `localStorage` (`ichat_accounts`)
- Current user auto-saved on every chat page load
- **Add Account**: main menu → account switcher sidebar → "Add Another Account" → logout → login page → after login, account is saved
- **Switch Account**: click another account card → confirm → logout → login page
- **Remove Account**: right-click a card in the switcher (current account cannot be removed)

### Files Changed (6)

| File | Change |
|---|---|
| `accounts/views.py` | `_safe_next_url()` helper with open-redirect validation; `login_view`/`logout_view` respect `?next=` |
| `static/js/chat.js` | localStorage helpers, `renderAccountsSwitcher()`, `switchToAccount()`, `addNewAccount()`, `autoSaveCurrentAccount()`, navigateSidebar integration |
| `static/css/chat.css` | Account card styles, current-account highlight, avatar gradient |
| `templates/components/sidebar.html` | Replace placeholder "Add Account" with real navigation; new accounts-switcher sidebar view |
| `templates/pages/chat.html` | Add `data-username` / `data-email` to key-manager script tag |
| `templates/pages/login.html` | Hidden `next` field to preserve redirect through POST |

### Validation

```
node --check static/js/chat.js
python manage.py check
python manage.py test chat.test_t11 accounts.tests    # 119 OK
python manage.py test chat.test_p2_issues              # 45 OK
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)